### PR TITLE
eslint config: import alphabetize and ignore case

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -125,7 +125,15 @@ module.exports = {
       "Undefined",
     ],
     "id-match": "error",
-    "import/order": "error",
+    "import/order": [
+      "error",
+      {
+        "alphabetize": {
+          "order": "asc",
+          "caseInsensitive": true,
+        }
+      }
+    ]
     "linebreak-style": "off",
     "max-classes-per-file": "off",
     "max-len": "off",


### PR DESCRIPTION
we just sort imports according to groups, this PR enables sorting within groups ignoring case