### PR TITLE
React-embed: Allow passing any string for `formsortEnv`

### DIFF
--- a/packages/react-embed/src/index.tsx
+++ b/packages/react-embed/src/index.tsx
@@ -70,7 +70,7 @@ const onMount = (
   );
 };
 
-function EmbedFlow(props: EmbedFlowProps) {
+const EmbedFlow: React.FunctionComponent<EmbedFlowProps> = (props) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const style = props.embedConfig?.style;
 
@@ -79,6 +79,6 @@ function EmbedFlow(props: EmbedFlowProps) {
   }, []);
 
   return <div ref={containerRef} style={style} />;
-}
+};
 
 export default EmbedFlow;

--- a/packages/react-embed/src/index.tsx
+++ b/packages/react-embed/src/index.tsx
@@ -10,7 +10,7 @@ interface ILoadProps {
   flowLabel: string;
   variantLabel?: string;
   responderUuid?: string;
-  formsortEnv?: 'staging' | 'production';
+  formsortEnv?: string;
   queryParams?: Array<[string, string]>;
   embedConfig?: IFormsortWebEmbedConfig;
 }

--- a/packages/react-embed/src/index.tsx
+++ b/packages/react-embed/src/index.tsx
@@ -5,12 +5,18 @@ import FormsortWebEmbed, {
 } from '@formsort/web-embed-api';
 import React, { useEffect, useRef } from 'react';
 
+// Using this type to preserve auto-complete for default environments
+// while allowing any other string to be passed.
+// See https://github.com/microsoft/TypeScript/issues/29729
+type LiteralUnion<T extends U, U = string> = T | (U & Record<never, never>);
+type FormsortEnv = LiteralUnion<'staging' | 'production'>;
+
 interface ILoadProps {
   clientLabel: string;
   flowLabel: string;
   variantLabel?: string;
   responderUuid?: string;
-  formsortEnv?: string;
+  formsortEnv?: FormsortEnv;
   queryParams?: Array<[string, string]>;
   embedConfig?: IFormsortWebEmbedConfig;
 }
@@ -64,7 +70,7 @@ const onMount = (
   );
 };
 
-const EmbedFlow: React.FunctionComponent<EmbedFlowProps> = (props) => {
+function EmbedFlow(props: EmbedFlowProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const style = props.embedConfig?.style;
 
@@ -73,6 +79,6 @@ const EmbedFlow: React.FunctionComponent<EmbedFlowProps> = (props) => {
   }, []);
 
   return <div ref={containerRef} style={style} />;
-};
+}
 
 export default EmbedFlow;


### PR DESCRIPTION
Since users of Formsort can define custom environments, we allow passing any string for the `formSortEnv` prop in react-embed. This PR updates the prop, and defines a custom type to preserve the auto-complete for the default environments.

### Screenshots

Intellisense for default environments:
<img width="731" alt="Screen Shot 2021-08-03 at 4 59 03 PM" src="https://user-images.githubusercontent.com/12574319/128085653-ad3ca9b3-3575-4700-ab89-b679876bfadc.png">
Other values are allowed:
<img width="533" alt="Screen Shot 2021-08-03 at 5 03 13 PM" src="https://user-images.githubusercontent.com/12574319/128085764-f79b71ac-1034-435e-99cb-210518155dff.png">
