### PR TITLE
Refactor and update web-embed message types 

### DIFF
--- a/packages/web-embed-api/src/index.ts
+++ b/packages/web-embed-api/src/index.ts
@@ -5,7 +5,7 @@ import {
   IIFrameResizeEventData,
 } from './interfaces';
 import {
-  isWebEmbedEventData,
+  isIWebEmbedEventData,
   isIFrameRedirectEventData,
   isIFrameResizeEventData,
   isIframeAnalyticsEventData,
@@ -114,7 +114,7 @@ const FormsortWebEmbed = (
       return;
     }
 
-    if (!isWebEmbedEventData(data)) {
+    if (!isIWebEmbedEventData(data)) {
       return;
     }
 

--- a/packages/web-embed-api/src/interfaces.d.ts
+++ b/packages/web-embed-api/src/interfaces.d.ts
@@ -27,27 +27,27 @@ export interface IFlowAnswers {
   [answerKey: string]: IAnswer;
 }
 
-interface WebEmbedEventData  {
-  type: WebEmbedMessage;
+interface IWebEmbedEventData<Type extends WebEmbedMessage = WebEmbedMessage> {
+  type: Type;
 }
 
-export interface IIFrameAnalyticsEventData extends WebEmbedEventData {
+export interface IIFrameAnalyticsEventData
+  extends IWebEmbedEventData<WebEmbedMessage.EMBED_EVENT_MSG> {
   createdAt: Date;
   eventType: AnalyticsEventType;
-  type: WebEmbedMessage.EMBED_EVENT_MSG;
   // Answers are only available when the iframe is embedded in a whitelisted domain
   answers: IFlowAnswers | undefined;
 }
 
-export interface IIFrameRedirectEventData extends WebEmbedEventData {
+export interface IIFrameRedirectEventData
+  extends IWebEmbedEventData<WebEmbedMessage.EMBED_REDIRECT_MSG> {
   payload: string;
-  type: WebEmbedMessage.EMBED_REDIRECT_MSG
 }
 
-export interface IIFrameResizeEventData extends WebEmbedEventData {
+export interface IIFrameResizeEventData
+  extends IWebEmbedEventData<WebEmbedMessage.EMBED_RESIZE_MSG> {
   payload: {
     width?: number;
     height?: number;
   };
-  type: WebEmbedMessage.EMBED_REDIRECT_MSG
 }

--- a/packages/web-embed-api/src/interfaces.d.ts
+++ b/packages/web-embed-api/src/interfaces.d.ts
@@ -1,20 +1,53 @@
 import { AnalyticsEventType, WebEmbedMessage } from '@formsort/constants';
 
-export interface IIFrameAnalyticsEventData {
+/**
+ * @TODO: these types should be moved to @formsort/constants
+ * And used by both formsort/web and web-embed-api
+ */
+
+export type JSONPrimitive = string | boolean | number;
+
+export interface IAddressObject {
+  raw?: string;
+  address_1: string;
+  address_2?: string;
+  city: string;
+  state: string;
+  postal_code: string;
+  country?: string;
+}
+
+export type IAnswer =
+  | undefined
+  | JSONPrimitive
+  | JSONPrimitive[]
+  | Partial<IAddressObject>;
+
+export interface IFlowAnswers {
+  [answerKey: string]: IAnswer;
+}
+
+interface WebEmbedEventData  {
+  type: WebEmbedMessage;
+}
+
+export interface IIFrameAnalyticsEventData extends WebEmbedEventData {
   createdAt: Date;
   eventType: AnalyticsEventType;
   type: WebEmbedMessage.EMBED_EVENT_MSG;
+  // Answers are only available when the iframe is embedded in a whitelisted domain
+  answers: IFlowAnswers | undefined;
 }
 
-export interface IIFrameRedirectEventData {
+export interface IIFrameRedirectEventData extends WebEmbedEventData {
   payload: string;
-  type: WebEmbedMessage.EMBED_REDIRECT_MSG;
+  type: WebEmbedMessage.EMBED_REDIRECT_MSG
 }
 
-export interface IIFrameResizeEventData {
+export interface IIFrameResizeEventData extends WebEmbedEventData {
   payload: {
     width?: number;
     height?: number;
   };
-  type: WebEmbedMessage.EMBED_RESIZE_MSG;
+  type: WebEmbedMessage.EMBED_REDIRECT_MSG
 }

--- a/packages/web-embed-api/src/typeGuards.test.ts
+++ b/packages/web-embed-api/src/typeGuards.test.ts
@@ -1,0 +1,18 @@
+import { WebEmbedMessage } from '@formsort/constants';
+import { isIWebEmbedEventData } from './typeGuards';
+
+describe('isIWebEmbedEventData', () => {
+  test.each([1, 'hello', null, undefined, {}, { type: 'hello' }])(
+    '%p is not IWebEmbedEventData',
+    (val) => {
+      expect(isIWebEmbedEventData(val)).toEqual(false);
+    }
+  );
+
+  test.each(Object.values(WebEmbedMessage).map((type) => ({ type })))(
+    '%p is IWebEmbedEventData',
+    (val) => {
+      expect(isIWebEmbedEventData(val)).toEqual(true);
+    }
+  );
+});

--- a/packages/web-embed-api/src/typeGuards.ts
+++ b/packages/web-embed-api/src/typeGuards.ts
@@ -3,7 +3,7 @@ import {
   IIFrameAnalyticsEventData,
   IIFrameRedirectEventData,
   IIFrameResizeEventData,
-  WebEmbedEventData,
+  IWebEmbedEventData,
 } from './interfaces';
 
 function isRecord(val: unknown): val is { [key: string]: unknown } {
@@ -14,8 +14,23 @@ function isString(val: unknown): val is string {
   return typeof val === 'string';
 }
 
-export function isWebEmbedEventData(val: unknown): val is WebEmbedEventData {
-  return isRecord(val) && isString(val.type);
+/**
+ * Checks if `val` is equal to one of the values of the enum
+ * @param val
+ * @param anEnum
+ */
+const isEnumMember = <EnumType extends { [key: string]: unknown }>(
+  val: unknown,
+  anEnum: EnumType
+): val is EnumType[keyof EnumType] =>
+  Object.values(anEnum).includes(val as EnumType[keyof EnumType]);
+
+export function isIWebEmbedEventData(val: unknown): val is IWebEmbedEventData {
+  return (
+    isRecord(val) &&
+    isString(val.type) &&
+    isEnumMember(val.type, WebEmbedMessage)
+  );
 }
 
 /**
@@ -25,19 +40,19 @@ export function isWebEmbedEventData(val: unknown): val is WebEmbedEventData {
  */
 
 export function isIframeAnalyticsEventData(
-  data: WebEmbedEventData
+  data: IWebEmbedEventData
 ): data is IIFrameAnalyticsEventData {
   return data.type === WebEmbedMessage.EMBED_EVENT_MSG;
 }
 
 export function isIFrameRedirectEventData(
-  data: WebEmbedEventData
+  data: IWebEmbedEventData
 ): data is IIFrameRedirectEventData {
   return data.type === WebEmbedMessage.EMBED_REDIRECT_MSG;
 }
 
 export function isIFrameResizeEventData(
-  data: WebEmbedEventData
+  data: IWebEmbedEventData
 ): data is IIFrameResizeEventData {
   return data.type === WebEmbedMessage.EMBED_RESIZE_MSG;
 }

--- a/packages/web-embed-api/src/typeGuards.ts
+++ b/packages/web-embed-api/src/typeGuards.ts
@@ -1,0 +1,43 @@
+import { WebEmbedMessage } from '@formsort/constants';
+import {
+  IIFrameAnalyticsEventData,
+  IIFrameRedirectEventData,
+  IIFrameResizeEventData,
+  WebEmbedEventData,
+} from './interfaces';
+
+function isRecord(val: unknown): val is { [key: string]: unknown } {
+  return val !== null && typeof val === 'object';
+}
+
+function isString(val: unknown): val is string {
+  return typeof val === 'string';
+}
+
+export function isWebEmbedEventData(val: unknown): val is WebEmbedEventData {
+  return isRecord(val) && isString(val.type);
+}
+
+/**
+ * Note: The type guards below are not comprehensive -
+ * i.e. we are not checking that all properties of the expected type exist
+ * on the given value.
+ */
+
+export function isIframeAnalyticsEventData(
+  data: WebEmbedEventData
+): data is IIFrameAnalyticsEventData {
+  return data.type === WebEmbedMessage.EMBED_EVENT_MSG;
+}
+
+export function isIFrameRedirectEventData(
+  data: WebEmbedEventData
+): data is IIFrameRedirectEventData {
+  return data.type === WebEmbedMessage.EMBED_REDIRECT_MSG;
+}
+
+export function isIFrameResizeEventData(
+  data: WebEmbedEventData
+): data is IIFrameResizeEventData {
+  return data.type === WebEmbedMessage.EMBED_RESIZE_MSG;
+}


### PR DESCRIPTION
This PR updates the web-embed package:
- Update interface types for events
- Add and use basic type guards to determine window message event type