### PR TITLE
re-boostrap - constants package version in lockfile

### DIFF
--- a/packages/constants/package-lock.json
+++ b/packages/constants/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@formsort/constants",
-	"version": "1.2.1",
+	"version": "1.3.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@formsort/constants",
-			"version": "1.2.1",
+			"version": "1.3.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/jest": "^26.0.19",


### PR DESCRIPTION
- Running `lerna boostrap` resulted in the version of `@formsort/constants` to be updated within its own `package-lock.json `. This aligns with the version assigned in [constants/package.json](https://github.com/formsort/oss/blob/master/packages/constants/package.json#L3) - updated in PR [Add responder_user_id to constants](https://github.com/formsort/oss/commit/d5befd5c7837003dea1775631a9f814bc36a15cd)