### PR TITLE
Add example project for web-embed using web components

### DIFF
--- a/packages/web-embed-api/examples/web-components/lit/.gitignore
+++ b/packages/web-embed-api/examples/web-components/lit/.gitignore
@@ -1,0 +1,2 @@
+.cache
+dist

--- a/packages/web-embed-api/examples/web-components/lit/README.md
+++ b/packages/web-embed-api/examples/web-components/lit/README.md
@@ -1,0 +1,17 @@
+# Example for embedding Formsort using [Lit](https://lit.dev/) Web Components
+
+The project was bundled with [Parcel](https://parceljs.org/cli.html).
+
+
+### Instructions
+
+1. Install dependencies using `npm install`.
+2. Add an `.env` file to the project root with the following variables:
+```
+CLIENT = my-client
+FLOW = first-flow
+VARIANT = main
+```
+Also, you can optionally add a value `FORMSORT_ORIGIN`, if different then the default `https://flow.formsort.com`.
+
+3. Start the project using either `npm start` or `parcel index.html`.

--- a/packages/web-embed-api/examples/web-components/lit/README.md
+++ b/packages/web-embed-api/examples/web-components/lit/README.md
@@ -2,16 +2,18 @@
 
 The project was bundled with [Parcel](https://parceljs.org/cli.html).
 
-
 ### Instructions
 
+1. Install the [parcel](https://parceljs.org/cli.html) package bundler: `npm install -g parcel-bundler `
 1. Install dependencies using `npm install`.
-2. Add an `.env` file to the project root with the following variables:
+1. Add an `.env` file to the project root with the following variables:
+
 ```
 CLIENT = my-client
 FLOW = first-flow
 VARIANT = main
 ```
+
 Also, you can optionally add a value `FORMSORT_ORIGIN`, if different then the default `https://flow.formsort.com`.
 
-3. Start the project using either `npm start` or `parcel index.html`.
+1. Start the project using either `npm start` or `parcel index.html`.

--- a/packages/web-embed-api/examples/web-components/lit/index.html
+++ b/packages/web-embed-api/examples/web-components/lit/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <script src="./index.ts"></script>
+  </head>
+  <body>
+    <root-element></root-element>
+  </body>
+</html>

--- a/packages/web-embed-api/examples/web-components/lit/index.ts
+++ b/packages/web-embed-api/examples/web-components/lit/index.ts
@@ -1,0 +1,116 @@
+import FormsortWebEmbed from '@formsort/web-embed-api';
+import { LitElement, html, css } from 'lit';
+import { customElement, state } from 'lit/decorators';
+import { createRef, ref } from 'lit/directives/ref';
+
+const FORMSORT_ORIGIN =
+  process.env.FORMSORT_ORIGIN || 'https://flow.formsort.com';
+const CLIENT = process.env.CLIENT;
+const FLOW = process.env.FLOW;
+const VARIANT = process.env.VARIANT;
+
+interface LoggedEvent {
+  name: string;
+  properties: string;
+}
+
+@customElement('root-element')
+class RootElement extends LitElement {
+  static styles = css`
+    .container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      width: 100%;
+    }
+    .iframe-container {
+      width: 50%;
+    }
+    iframe {
+      width: 100%;
+      height: 350px;
+      margin-bottom: 1rem;
+    }
+    #event-list {
+      width: 50%;
+    }
+    .event-properties {
+      white-space: pre-line;
+    }
+  `;
+
+  @state()
+  loggedEvents: LoggedEvent[] = [];
+
+  formsortEmbedRef = createRef<HTMLElement>();
+
+  private addToEventLog(eventName: string, eventProps: { [key: string]: any }) {
+    this.loggedEvents = [
+      ...this.loggedEvents,
+      { name: eventName, properties: JSON.stringify(eventProps) },
+    ];
+  }
+
+  firstUpdated() {
+    // Embed Formsort in the page
+    const formsortEbmedElem = this.formsortEmbedRef.value!;
+    const embed = FormsortWebEmbed(formsortEbmedElem, {
+      origin: FORMSORT_ORIGIN,
+    });
+
+    // Add analytics events to event log
+    for (const event of [
+      'FlowLoaded',
+      'FlowFinalized',
+      'FlowClosed',
+      'StepLoaded',
+      'StepCompleted',
+    ] as const) {
+      embed.addEventListener(event, (eventProps) =>
+        this.addToEventLog(event, eventProps)
+      );
+    }
+
+    // Add redirect event to event log
+    embed.addEventListener('redirect', (eventProps) => {
+      this.addToEventLog('redirect', eventProps);
+      // Cancel redirect to stay on the current page
+      return {
+        cancel: true,
+      };
+    });
+
+    if (!CLIENT || !FLOW || !VARIANT) {
+      window.alert(
+        'Client, Flow and Variant must be provided in the .env file.'
+      );
+      return;
+    }
+
+    embed.loadFlow(CLIENT, FLOW, VARIANT);
+  }
+
+  render() {
+    return html`<div class="container">
+      <h1>Formsort Embed Example</h1>
+      <div class="iframe-container" ${ref(this.formsortEmbedRef)}></div>
+      <div id="event-list">
+        <div>Event Log:</div>
+        <ul>
+          ${this.loggedEvents.map(
+            (event, index) => html`
+              <li>Event No. ${index + 1}:</li>
+              <ul>
+                <li>Event name: <i>${event.name}</i></li>
+                <li>
+                  Event properties:
+                  <pre class="event-properties">${event.properties}</pre>
+                </li>
+              </ul>
+            `
+          )}
+        </ul>
+      </div>
+    </div>`;
+  }
+}

--- a/packages/web-embed-api/examples/web-components/lit/index.ts
+++ b/packages/web-embed-api/examples/web-components/lit/index.ts
@@ -53,8 +53,8 @@ class RootElement extends LitElement {
 
   firstUpdated() {
     // Embed Formsort in the page
-    const formsortEbmedElem = this.formsortEmbedRef.value!;
-    const embed = FormsortWebEmbed(formsortEbmedElem, {
+    const formsortEmbedElem = this.formsortEmbedRef.value!;
+    const embed = FormsortWebEmbed(formsortEmbedElem, {
       origin: FORMSORT_ORIGIN,
     });
 
@@ -76,7 +76,7 @@ class RootElement extends LitElement {
       this.addToEventLog('redirect', eventProps);
       // Cancel redirect to stay on the current page
       return {
-        cancel: true,
+        cancel: false,
       };
     });
 

--- a/packages/web-embed-api/examples/web-components/lit/index.ts
+++ b/packages/web-embed-api/examples/web-components/lit/index.ts
@@ -76,7 +76,7 @@ class RootElement extends LitElement {
       this.addToEventLog('redirect', eventProps);
       // Cancel redirect to stay on the current page
       return {
-        cancel: false,
+        cancel: true,
       };
     });
 

--- a/packages/web-embed-api/examples/web-components/lit/package-lock.json
+++ b/packages/web-embed-api/examples/web-components/lit/package-lock.json
@@ -1,0 +1,141 @@
+{
+  "name": "formsort-embed-example-lit",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "formsort-embed-example-lit",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@formsort/web-embed-api": "^1.3.0",
+        "lit": "^2.0.0-rc.4"
+      },
+      "devDependencies": {
+        "typescript": "^4.4.2"
+      }
+    },
+    "node_modules/@formsort/constants": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@formsort/constants/-/constants-1.3.0.tgz",
+      "integrity": "sha512-8oqewuEVMWPtPStk2u6VVzF0cwXsqYCPB3v6mRm5u5U18+ETC5E2R7+PbR1uIW4wi5hUBMeNH7+UXEevlFv5Pw=="
+    },
+    "node_modules/@formsort/web-embed-api": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@formsort/web-embed-api/-/web-embed-api-1.3.0.tgz",
+      "integrity": "sha512-s3MNlnHIJTA45Hb6Er4NqfEcT5oNgZsQ2Q2mlhsD5iYUD3DjOA0Rg39zInspMsdRBPl1ikzcK+3N1/XX27Bw+A==",
+      "dependencies": {
+        "@formsort/constants": "^1.2.1"
+      }
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.0-rc.4.tgz",
+      "integrity": "sha512-dJMha+4NFYdpnUJzRrWTFV5Hdp9QHWFuPnaoqonrKl4lGJVnYez9mu8ev9F/5KM47tjAjh22DuRHrdFDHfOijA=="
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
+      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+    },
+    "node_modules/lit": {
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.0.0-rc.4.tgz",
+      "integrity": "sha512-HPJrSvK377a1E5eSAUG+eTJWIOJFGNtnfbGPHY4vbc0Ud9GTFSwMEbeAOIJnA+5q92cafR38F1bWOyo4a2ncag==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.0.0-rc.2",
+        "lit-element": "^3.0.0-rc.2",
+        "lit-html": "^2.0.0-rc.4"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "3.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.0.0-rc.4.tgz",
+      "integrity": "sha512-6X7RCHTNhAWetVSr8VccALnRcn3W3VDqOfjY5cAfyfGq8Y9IbWnyBP8/ihpRg2atHbM2NsGL6pjDrFL9dRdIKg==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.0.0-rc.2",
+        "lit-html": "^2.0.0-rc.4"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.0.0-rc.5.tgz",
+      "integrity": "sha512-vFnjzqwQijC9By5F50c3sjI5PXPYoIvbGfpbbDOv+8BBRYdMR+FDYyMeCC3T3iIZx8EE6aIow2aTaG+HS5SV4A==",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  },
+  "dependencies": {
+    "@formsort/constants": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@formsort/constants/-/constants-1.3.0.tgz",
+      "integrity": "sha512-8oqewuEVMWPtPStk2u6VVzF0cwXsqYCPB3v6mRm5u5U18+ETC5E2R7+PbR1uIW4wi5hUBMeNH7+UXEevlFv5Pw=="
+    },
+    "@formsort/web-embed-api": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@formsort/web-embed-api/-/web-embed-api-1.3.0.tgz",
+      "integrity": "sha512-s3MNlnHIJTA45Hb6Er4NqfEcT5oNgZsQ2Q2mlhsD5iYUD3DjOA0Rg39zInspMsdRBPl1ikzcK+3N1/XX27Bw+A==",
+      "requires": {
+        "@formsort/constants": "^1.2.1"
+      }
+    },
+    "@lit/reactive-element": {
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.0-rc.4.tgz",
+      "integrity": "sha512-dJMha+4NFYdpnUJzRrWTFV5Hdp9QHWFuPnaoqonrKl4lGJVnYez9mu8ev9F/5KM47tjAjh22DuRHrdFDHfOijA=="
+    },
+    "@types/trusted-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
+      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+    },
+    "lit": {
+      "version": "2.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.0.0-rc.4.tgz",
+      "integrity": "sha512-HPJrSvK377a1E5eSAUG+eTJWIOJFGNtnfbGPHY4vbc0Ud9GTFSwMEbeAOIJnA+5q92cafR38F1bWOyo4a2ncag==",
+      "requires": {
+        "@lit/reactive-element": "^1.0.0-rc.2",
+        "lit-element": "^3.0.0-rc.2",
+        "lit-html": "^2.0.0-rc.4"
+      }
+    },
+    "lit-element": {
+      "version": "3.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.0.0-rc.4.tgz",
+      "integrity": "sha512-6X7RCHTNhAWetVSr8VccALnRcn3W3VDqOfjY5cAfyfGq8Y9IbWnyBP8/ihpRg2atHbM2NsGL6pjDrFL9dRdIKg==",
+      "requires": {
+        "@lit/reactive-element": "^1.0.0-rc.2",
+        "lit-html": "^2.0.0-rc.4"
+      }
+    },
+    "lit-html": {
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.0.0-rc.5.tgz",
+      "integrity": "sha512-vFnjzqwQijC9By5F50c3sjI5PXPYoIvbGfpbbDOv+8BBRYdMR+FDYyMeCC3T3iIZx8EE6aIow2aTaG+HS5SV4A==",
+      "requires": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "typescript": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
+      "dev": true
+    }
+  }
+}

--- a/packages/web-embed-api/examples/web-components/lit/package.json
+++ b/packages/web-embed-api/examples/web-components/lit/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "formsort-embed-example-lit",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "parcel index.html"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "typescript": "^4.4.2"
+  },
+  "dependencies": {
+    "@formsort/web-embed-api": "^1.3.0",
+    "lit": "^2.0.0-rc.4"
+  },
+  "browerslist": [
+    "Chrome > 50"
+  ]
+}

--- a/packages/web-embed-api/examples/web-components/lit/tsconfig.json
+++ b/packages/web-embed-api/examples/web-components/lit/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "strict": true,
+    "sourceMap": true,
+    "experimentalDecorators": true,
+    "target": "ES6"
+  }
+}


### PR DESCRIPTION
- Create an `examples` subfolder in the `web-embed` folder
- Add an example using a [web component](https://developer.mozilla.org/en-US/docs/Web/Web_Components) created with  [lit](https://lit.dev/).
- The example embeds a flow within a web page (client, flow, and variant name provided via `.env` file), registers listeners for all event types (analytics events and redirect event), and logs all events with their payloads onto the page. 


### Screenshot
<img width="338" alt="Screen Shot 2021-09-14 at 2 31 13 PM" src="https://user-images.githubusercontent.com/12574319/133314266-56f3b8ae-d1ea-4224-a0bf-0c78d21adee3.png">
