### PR TITLE
Add CHANGELOG and remove extraneous type

### DIFF
--- a/packages/web-embed-api/CHANGELOG.md
+++ b/packages/web-embed-api/CHANGELOG.md
@@ -1,0 +1,6 @@
+# 2.0.1
+
+- Embed event names now match the analytics event names (such as `"FlowLoaded"` instead of `"flowloaded"`).
+- `"StepLoaded"` and `"StepCompleted"` are now available to embeds.
+- When embedded in a whitelisted origin, event handlers now will receive answers, as `{ answers: { ... } }`
+- Embeds can now cancel redirects, by returning an object `{ cancel: true }` in the handler for the `redirect` event

--- a/packages/web-embed-api/CHANGELOG.md
+++ b/packages/web-embed-api/CHANGELOG.md
@@ -4,3 +4,4 @@
 - `"StepLoaded"` and `"StepCompleted"` are now available to embeds.
 - When embedded in a whitelisted origin, event handlers now will receive answers, as `{ answers: { ... } }`
 - Embeds can now cancel redirects, by returning an object `{ cancel: true }` in the handler for the `redirect` event
+- Add react@17 to peerDependencies

--- a/packages/web-embed-api/README.md
+++ b/packages/web-embed-api/README.md
@@ -100,6 +100,7 @@ Note that this is only possible if your style set defines a close button.
 #### StepLoaded `(answers?: { [key: string]: any }) => void`
 
 Set a callback to be called when a new step is loaded.
+
 This will happen once after the flow is loaded, if the user hasn't previously completed the flow. Subsequently, this event will happen following the completion of each step, except for the completion of the final step.
 
 #### StepCompleted `(answers?: { [key: string]: any }) => void`

--- a/packages/web-embed-api/src/index.ts
+++ b/packages/web-embed-api/src/index.ts
@@ -75,7 +75,6 @@ export interface IEventMap extends IAnalyticsEventMap {
     props: IRedirectEventProps
   ) => {
     cancel?: boolean;
-    customUrl?: string;
   } | void;
 }
 


### PR DESCRIPTION
The `customUrl` type annotation wasn't actually implemented, so it can
be removed