### PR TITLE
react-embed: allow react v17 as peer-dependency

### DIFF
--- a/packages/react-embed/package.json
+++ b/packages/react-embed/package.json
@@ -59,7 +59,7 @@
     "@formsort/web-embed-api": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "^16.13.0"
+    "react": "^16.13.0 || ^17.0.0"
   },
   "gitHead": "a17af03c2d02ba85c612e33204db18cddaaa00be"
 }


### PR DESCRIPTION
Allow react v17 as peer-dependency for react-embed, so that projects using v17 can use the package.