### PR TITLE
Update web-embed addEventListener to have appending behavior

### DIFF
--- a/packages/web-embed-api/src/index.test.ts
+++ b/packages/web-embed-api/src/index.test.ts
@@ -476,6 +476,41 @@ describe('FormsortWebEmbed', () => {
     expect(window.location.assign).toBeCalledWith(redirectUrl);
   });
 
+  test('handles redirecting to a URL if no callback returns `{cancel: true}`', async () => {
+    const embed = FormsortWebEmbed(document.body);
+    const iframe = document.body.querySelector('iframe')!;
+
+    const redirectCallback1 = jest.fn(() => ({ cancel: false }));
+    const redirectCallback2 = jest.fn(() => ({}));
+    const redirectCallback3 = jest.fn(() => ({}));
+
+    embed.addEventListener('redirect', redirectCallback1);
+    embed.addEventListener('redirect', redirectCallback2);
+    embed.addEventListener('redirect', redirectCallback3);
+
+    embed.loadFlow(clientLabel, flowLabel);
+
+    const redirectUrl = 'https://example.com';
+    const msg = new MessageEvent('message', {
+      source: iframe.contentWindow,
+      origin: DEFAULT_FLOW_ORIGIN,
+      data: {
+        type: WebEmbedMessage.EMBED_REDIRECT_MSG,
+        payload: redirectUrl,
+      },
+    });
+    mockPostMessage(msg);
+
+    expect(redirectCallback1).toBeCalledTimes(1);
+    expect(redirectCallback1).toBeCalledWith({ url: redirectUrl });
+    expect(redirectCallback2).toBeCalledTimes(1);
+    expect(redirectCallback2).toBeCalledWith({ url: redirectUrl });
+    expect(redirectCallback3).toBeCalledTimes(1);
+    expect(redirectCallback3).toBeCalledWith({ url: redirectUrl });
+    expect(window.location.assign).toBeCalledTimes(1);
+    expect(window.location.assign).toBeCalledWith(redirectUrl);
+  });
+
   test('Cancels redirect if callback returns `cancel: true`', async () => {
     const embed = FormsortWebEmbed(document.body);
     const iframe = document.body.querySelector('iframe')!;

--- a/packages/web-embed-api/src/index.test.ts
+++ b/packages/web-embed-api/src/index.test.ts
@@ -291,6 +291,33 @@ describe('FormsortWebEmbed', () => {
     expect(flowLoadedSpy).toBeCalledTimes(1);
   });
 
+  test('handles adding multiple event handlers', async () => {
+    const embed = FormsortWebEmbed(document.body);
+    const iframe = document.body.querySelector('iframe')!;
+
+    const flowLoadedSpy1 = jest.fn();
+    const flowLoadedSpy2 = jest.fn();
+
+    embed.addEventListener('FlowLoaded', flowLoadedSpy1);
+    embed.addEventListener('FlowLoaded', flowLoadedSpy2);
+
+    embed.loadFlow(clientLabel, flowLabel);
+
+    const msg = new MessageEvent('message', {
+      source: iframe.contentWindow,
+      origin: DEFAULT_FLOW_ORIGIN,
+      data: {
+        type: WebEmbedMessage.EMBED_EVENT_MSG,
+        createdAt: new Date(),
+        eventType: AnalyticsEventType.FlowLoaded,
+      },
+    });
+    mockPostMessage(msg);
+
+    expect(flowLoadedSpy1).toBeCalledTimes(1);
+    expect(flowLoadedSpy2).toBeCalledTimes(1);
+  });
+
   test('handles flow finalized event', async () => {
     const embed = FormsortWebEmbed(document.body);
     const iframe = document.body.querySelector('iframe')!;
@@ -469,6 +496,40 @@ describe('FormsortWebEmbed', () => {
     mockPostMessage(msg);
     expect(redirectCallback).toBeCalledTimes(1);
     expect(redirectCallback).toBeCalledWith({ url: redirectUrl });
+    expect(window.location.assign).not.toHaveBeenCalled();
+  });
+
+  test('Cancels redirect if any callback returns `cancel: true`', async () => {
+    const embed = FormsortWebEmbed(document.body);
+    const iframe = document.body.querySelector('iframe')!;
+
+    const redirectUrl = 'https://example.com';
+    const redirectCallback1 = jest.fn(() => ({ cancel: false }));
+    const redirectCallback2 = jest.fn(() => ({ cancel: true }));
+    const redirectCallback3 = jest.fn(() => ({}));
+
+    embed.addEventListener('redirect', redirectCallback1);
+    embed.addEventListener('redirect', redirectCallback2);
+    embed.addEventListener('redirect', redirectCallback3);
+
+    embed.loadFlow(clientLabel, flowLabel);
+
+    const msg = new MessageEvent('message', {
+      source: iframe.contentWindow,
+      origin: DEFAULT_FLOW_ORIGIN,
+      data: {
+        type: WebEmbedMessage.EMBED_REDIRECT_MSG,
+        payload: redirectUrl,
+      },
+    });
+    mockPostMessage(msg);
+
+    expect(redirectCallback1).toBeCalledTimes(1);
+    expect(redirectCallback1).toBeCalledWith({ url: redirectUrl });
+    expect(redirectCallback2).toBeCalledTimes(1);
+    expect(redirectCallback2).toBeCalledWith({ url: redirectUrl });
+    expect(redirectCallback3).toBeCalledTimes(1);
+    expect(redirectCallback3).toBeCalledWith({ url: redirectUrl });
     expect(window.location.assign).not.toHaveBeenCalled();
   });
 

--- a/packages/web-embed-api/src/index.ts
+++ b/packages/web-embed-api/src/index.ts
@@ -11,7 +11,7 @@ import {
   isIFrameResizeEventData,
   isIframeAnalyticsEventData,
 } from './typeGuards';
-import { addToArrayMap, isEmpty } from './utils';
+import { addToArrayMap, isEmpty, removeFromArrayMap } from './utils';
 
 const DEFAULT_FLOW_ORIGIN = `https://flow.formsort.com`;
 
@@ -26,6 +26,10 @@ export interface IFormsortWebEmbed {
   addEventListener<K extends keyof IEventMap>(
     eventName: K,
     fn: IEventMap[K]
+  ): void;
+  removeEventListener<K extends keyof IEventMap>(
+    eventName: K,
+    eventListener: IEventMap[K]
   ): void;
 }
 
@@ -242,6 +246,12 @@ const FormsortWebEmbed = (
       fn: IEventMap[K]
     ): void {
       addToArrayMap(eventListenersArrayMap, eventName, fn);
+    },
+    removeEventListener<K extends keyof IEventMap>(
+      eventName: K,
+      eventListener: IEventMap[K]
+    ): void {
+      removeFromArrayMap(eventListenersArrayMap, eventName, eventListener);
     },
   };
 };

--- a/packages/web-embed-api/src/index.ts
+++ b/packages/web-embed-api/src/index.ts
@@ -113,7 +113,7 @@ const FormsortWebEmbed = (
 
     if (!isEmpty(eventListenersArrayMap.redirect)) {
       let cancelRedirect = false;
-      // Cancel redirect if any of the redirect listeners return `{ cancel:  true }`
+      // Cancel redirect if any of the redirect listeners return `{ cancel: true }`
       for (const redirectListener of eventListenersArrayMap.redirect) {
         const { cancel } = redirectListener({ url, answers }) || {};
         if (!cancelRedirect && cancel) {

--- a/packages/web-embed-api/src/interfaces.ts
+++ b/packages/web-embed-api/src/interfaces.ts
@@ -35,7 +35,9 @@ export interface IRedirectEventProps extends IBaseEventProps {
   url: string;
 }
 
-export interface IWebEmbedEventData<Type extends WebEmbedMessage = WebEmbedMessage> {
+export interface IWebEmbedEventData<
+  Type extends WebEmbedMessage = WebEmbedMessage
+> {
   type: Type;
 }
 
@@ -64,3 +66,7 @@ export interface IIFrameResizeEventData
     height?: number;
   };
 }
+
+export type ElementType<T extends unknown[]> = T[number];
+
+export type ArrayMap = Record<string, unknown[]>;

--- a/packages/web-embed-api/src/utils.ts
+++ b/packages/web-embed-api/src/utils.ts
@@ -1,0 +1,13 @@
+import { ArrayMap, ElementType } from './interfaces';
+
+export function addToArrayMap<T extends ArrayMap, K extends keyof T>(
+  arrayMap: T,
+  key: K,
+  val: ElementType<T[K]>
+) {
+  arrayMap[key].push(val);
+}
+
+export function isEmpty<T>(val: T[]): val is [] {
+  return val.length === 0;
+}

--- a/packages/web-embed-api/src/utils.ts
+++ b/packages/web-embed-api/src/utils.ts
@@ -8,6 +8,16 @@ export function addToArrayMap<T extends ArrayMap, K extends keyof T>(
   arrayMap[key].push(val);
 }
 
+export function removeFromArrayMap<
+  T extends Record<string, unknown[]>,
+  K extends keyof T
+>(arrayMap: T, key: K, val: ElementType<T[K]>) {
+  const indexOfElem = arrayMap[key].findIndex((elem) => elem === val);
+  if (indexOfElem !== -1) {
+    arrayMap[key].splice(indexOfElem, 1);
+  }
+}
+
 export function isEmpty<T>(val: T[]): val is [] {
   return val.length === 0;
 }

--- a/packages/web-embed-api/src/utils.ts
+++ b/packages/web-embed-api/src/utils.ts
@@ -8,10 +8,11 @@ export function addToArrayMap<T extends ArrayMap, K extends keyof T>(
   arrayMap[key].push(val);
 }
 
-export function removeFromArrayMap<
-  T extends Record<string, unknown[]>,
-  K extends keyof T
->(arrayMap: T, key: K, val: ElementType<T[K]>) {
+export function removeFromArrayMap<T extends ArrayMap, K extends keyof T>(
+  arrayMap: T,
+  key: K,
+  val: ElementType<T[K]>
+) {
   const indexOfElem = arrayMap[key].findIndex((elem) => elem === val);
   if (indexOfElem !== -1) {
     arrayMap[key].splice(indexOfElem, 1);


### PR DESCRIPTION
- Currently `embed.addEventListener` *replaces* the listener registered for that event type.
- Update `eventListeners` to be `eventListenersArrayMap`, so that it contains an array of listeners for each event type.
- Update  `embed.addEventListener`, so that it adds the event listener to the list of listeners registered for that event type.
- Add a `removeEventListener` method that, given an event name and a listener, removes the listener from the the list of listeners registered for that event type.