### PR TITLE
run tests in ci for react-embed and constants

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,3 +27,39 @@ jobs:
         working-directory: './packages/web-embed-api'
       - run: npm test
         working-directory: './packages/web-embed-api'
+
+  react-embed-test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm run bootstrap
+      - run: npm run build --if-present
+        working-directory: './packages/react-embed'
+      - run: npm test
+        working-directory: './packages/react-embed'
+
+  constants-test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm run bootstrap
+      - run: npm run build --if-present
+        working-directory: './packages/constants'
+      - run: npm test
+        working-directory: './packages/constants'

--- a/packages/react-embed/src/__tests__/EmbedFlow.test.tsx
+++ b/packages/react-embed/src/__tests__/EmbedFlow.test.tsx
@@ -14,13 +14,17 @@ describe('EmbedFlow component', () => {
   let loadMock: jest.Mock;
   let embedMock: IFormsortWebEmbed;
   let addEventListenerMock: jest.Mock;
+  let removeEventListenerMock: jest.Mock;
+
   beforeEach(() => {
     loadMock = jest.fn();
     addEventListenerMock = jest.fn();
+    removeEventListenerMock = jest.fn();
     embedMock = {
       loadFlow: loadMock,
       setSize: jest.fn(),
       addEventListener: addEventListenerMock,
+      removeEventListener: removeEventListenerMock,
     };
     mockWebEmbedApi.mockReturnValueOnce(embedMock);
   });


### PR DESCRIPTION
- Currently our github workflow is set to only run the tests for the `web-embed-api` package.
- This PR updates the workflow to also run the tests for the `react-embed` and `constants` packages.
- The PR also fixes a typescript error in the tests for `react-embed`.