### PR TITLE
cleanup react-embed example

### DIFF
--- a/packages/react-embed/example/event-log/README.md
+++ b/packages/react-embed/example/event-log/README.md
@@ -4,7 +4,7 @@ The project was bundled with [Parcel](https://parceljs.org/cli.html).
 
 ### Instructions
 
-1. Install dependencies using `npm install` or `yarn`.
+1. Install dependencies using `npm install`.
 1. Add an `.env` file to the project root with the following variables:
 
 ```
@@ -15,7 +15,7 @@ VARIANT=main
 
 You can optionally add a `FORMSORT_ORIGIN` variable, if this value is different then the default `https://flow.formsort.com`.
 
-Start the project using `npm start` or `yarn start`. 
+Start the project using `npm start`. 
 
 _note_: In order to receive answers from the embedded flow, the domain in which it is embedded must be whitelisted. To do so in the Formsort studio, go to the "security" tab and add the url in "Allowed embedding domains". To work when running this project locally, you can use an application such as [ngrok](https://ngrok.com/) to create a public url for the locally running server on `localhost:1234`. Remember to navigate in your browser to the url that starts with `https://`. 
 

--- a/packages/react-embed/example/event-log/package.json
+++ b/packages/react-embed/example/event-log/package.json
@@ -21,7 +21,6 @@
     "@types/react": "^17.0.22",
     "@types/react-dom": "^17.0.9",
     "parcel": "^2.0.1",
-    "parcel-bundler": "^1.12.5",
     "typescript": "^4.4.3"
   }
 }


### PR DESCRIPTION
- remove old parcel version. The package name was `parcel-bundler` and the one for the new version is `parcel`.
- Use only `npm` in the example for consistency. 