### PR TITLE
custom-question-api: allow setting question size with string value

### DIFF
--- a/packages/custom-question-api/README.md
+++ b/packages/custom-question-api/README.md
@@ -103,12 +103,14 @@ getResponderUuid() => Promise<string>
 Get the current responder's UUID. Useful if you need to look something up about this user that isn't within the Formsort answer set.
 
 ```tsx
-setQuestionSize(width?: number, height?: number) => void
+setQuestionSize(width?: number | string, height?: number | string) => void
 ```
 
-Sets the width and height of the question within Formsort.
+Sets the width and height of the question within Formsort. The default unit of measurement when passing a number is pixels (px). A different unit of measurement can be passed as a string.
+For example, `'2em'` or `'100%'`.
 
 To avoid jumpiness, if you know the size of your component beforehand, it's best to set the default width and height within the custom question directly within the Formsort studio. Use `setQuestionSize` when you do not know the dimensions of your question component beforehand, and want to make sure that Formsort gives it enough size to render without scrollbars.
+
 
 For example, if you implement your custom question as a React component, you may want to measure the component once it's rendered and tell Formsort its height and width:
 

--- a/packages/custom-question-api/src/index.ts
+++ b/packages/custom-question-api/src/index.ts
@@ -5,7 +5,10 @@ import { getValueFromWindowParent, sendMessageToWindowParent } from './utils';
 type AnswerPrimitiveType = number | string | boolean | object;
 type AnswerType = AnswerPrimitiveType | AnswerPrimitiveType[];
 
-export const setQuestionSize = (width?: number, height?: number) => {
+export const setQuestionSize = (
+  width?: number | string,
+  height?: number | string
+) => {
   sendMessageToWindowParent(CustomQuestionMessage.SET_QUESTION_SIZE_MSG, {
     width,
     height,


### PR DESCRIPTION
- update the type definition of  `setQuestionSize` to allow passing string values for height and width. This is supported in the flow.