### PR TITLE
add callback for unauthorized message

### DIFF
--- a/packages/constants/src/web-embed-message/index.ts
+++ b/packages/constants/src/web-embed-message/index.ts
@@ -1,9 +1,10 @@
 enum WebEmbedMessage {
   EMBED_EVENT_MSG = 'ƒ_wee',
-  EMBED_TOKEN_REQUEST_MSG = 'ƒ_wetreq',
-  EMBED_TOKEN_RESPONSE_MSG = 'ƒ_wetres',
   EMBED_REDIRECT_MSG = 'ƒ_wer',
   EMBED_RESIZE_MSG = 'ƒ_wes',
+  EMBED_TOKEN_REQUEST_MSG = 'ƒ_wetreq',
+  EMBED_TOKEN_RESPONSE_MSG = 'ƒ_wetres',
+  EMBED_UNAUTHORIZED_MSG = 'ƒ_weua',
 }
 
 export default WebEmbedMessage;

--- a/packages/web-embed-api/README.md
+++ b/packages/web-embed-api/README.md
@@ -126,6 +126,12 @@ If the callback does not return a value, Formsort will handle the redirect as us
 
 This is helpful if you're embedding Formsort within a single-page app that has custom URL route handling.
 
+#### unauthorized `() => void`
+
+Set a callback for unauthorized Formsort messages.
+
+This callback is used when the Formsort Flow is authenticated but the ID token is missing or invalid.
+
 ## Development
 
 By default, the web embed accesses the production formsort servers. If you would like to point to another flow server, set `origin` in the config to the correct base URL, for example:

--- a/packages/web-embed-api/src/index.ts
+++ b/packages/web-embed-api/src/index.ts
@@ -15,6 +15,7 @@ import {
   isIFrameResizeEventData,
   isIFrameAnalyticsEventData,
   isIFrameTokenRequestEventData,
+  isIFrameUnauthorizedEventData,
 } from './typeGuards';
 import { addToArrayMap, isEmpty, removeFromArrayMap } from './utils';
 
@@ -92,6 +93,7 @@ export interface IEventMap extends IAnalyticsEventMap {
   ) => {
     cancel?: boolean;
   } | void;
+  unauthorized: () => void;
 }
 
 export type IEventListenersArrayMap = {
@@ -122,6 +124,7 @@ const FormsortWebEmbed = (
     StepLoaded: [],
     StepCompleted: [],
     redirect: [],
+    unauthorized: [],
   };
 
   const onTokenRequest = (data: IIFrameTokenRequestEventData) => {
@@ -168,6 +171,14 @@ const FormsortWebEmbed = (
     }
   };
 
+  const onUnauthorizedMessage = () => {
+    if (!isEmpty(eventListenersArrayMap.unauthorized)) {
+      for (const unathorizedListener of eventListenersArrayMap.unauthorized) {
+        unathorizedListener();
+      }
+    }
+  }
+
   const onResizeMessage = (data: IIFrameResizeEventData) => {
     const { width, height } = data.payload;
     setSize(width, height);
@@ -199,6 +210,8 @@ const FormsortWebEmbed = (
       onRedirectMessage(data);
     } else if (isIFrameResizeEventData(data) && autoHeight) {
       onResizeMessage(data);
+    } else if (isIFrameUnauthorizedEventData(data)) {
+      onUnauthorizedMessage();
     }
   };
 

--- a/packages/web-embed-api/src/typeGuards.ts
+++ b/packages/web-embed-api/src/typeGuards.ts
@@ -63,3 +63,9 @@ export function isIFrameResizeEventData(
 ): data is IIFrameResizeEventData {
   return data.type === WebEmbedMessage.EMBED_RESIZE_MSG;
 }
+
+export function isIFrameUnauthorizedEventData(
+  data: IWebEmbedEventData
+): data is IIFrameResizeEventData {
+  return data.type === WebEmbedMessage.EMBED_UNAUTHORIZED_MSG;
+}


### PR DESCRIPTION
Add the ability to listen to `unauthorized` events in the Web Embed API.