### PR TITLE
ci: Add publishing through GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Publish Package
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: Name of the package to release
+        required: true
+      version:
+        description: Version to release
+        required: true
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: release
+    name: 'Publish a new version'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Publish
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: >-
+          yarn workspace @formsort/${{ github.event.inputs.package }} run release ${{ github.event.inputs.version }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
   ],
   "yaml.schemas": {
     "https://json.schemastore.org/github-workflow.json": "<workdir>/.github/workflows/build.yml"
-  }
+  },
+  "cSpell.words": ["formsort"]
 }


### PR DESCRIPTION
Adds a GitHub workflow that can be triggered from the UI, or CLI to publish a package automatically from the CI. The workflow uses the `release` environment which contains the `NPM_TOKEN` secret for the `formsort-release` account and is protected by environment rules: https://github.com/formsort/oss/settings/environments/448906217/edit

Finishes off APP-12