### PR TITLE
Remove Client label from the default Flow Url

### DIFF
--- a/packages/react-embed/package.json
+++ b/packages/react-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formsort/react-embed",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Embed formsort flows in react components",
   "publishConfig": {
     "access": "public",
@@ -56,7 +56,7 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "@formsort/web-embed-api": "^2.2.1"
+    "@formsort/web-embed-api": "^2.2.2"
   },
   "peerDependencies": {
     "react": "^16.13.0 || ^17.0.0"

--- a/packages/web-embed-api/examples/authenticated-flow/package.json
+++ b/packages/web-embed-api/examples/authenticated-flow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formsort/embed-example-authenticated-flow",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Formsort Embed using an authenticated flow",
   "main": "src/index.js",
   "engines": {
@@ -16,7 +16,7 @@
   "author": "Formsort Engineering <engineering@formsort.com>",
   "license": "ISC",
   "dependencies": {
-    "@formsort/web-embed-api": "2.2.1"
+    "@formsort/web-embed-api": "2.2.2"
   },
   "devDependencies": {
     "css-loader": "^6.7.1",

--- a/packages/web-embed-api/examples/formsort-embed-example-lit/package.json
+++ b/packages/web-embed-api/examples/formsort-embed-example-lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsort-embed-example-lit",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "source": "index.html",
   "scripts": {
@@ -19,7 +19,7 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "@formsort/web-embed-api": "^2.2.1",
+    "@formsort/web-embed-api": "^2.2.2",
     "lit": "^2.2.1"
   },
   "browerslist": [

--- a/packages/web-embed-api/package.json
+++ b/packages/web-embed-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formsort/web-embed-api",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Embed Formsort flows within other webpages",
   "publishConfig": {
     "access": "public",

--- a/packages/web-embed-api/src/index.test.ts
+++ b/packages/web-embed-api/src/index.test.ts
@@ -117,7 +117,7 @@ describe('FormsortWebEmbed', () => {
 
     const iframe = iframes[0];
     expect(iframe.src).toBe(
-      `https://${clientLabel}.formsort.app/client/${clientLabel}/flow/${flowLabel}`
+      `https://${clientLabel}.formsort.app/flow/${flowLabel}`
     );
   });
 
@@ -162,7 +162,7 @@ describe('FormsortWebEmbed', () => {
     const iframe = iframes[0];
     expect(iframe.src).toBe(
       `https://${clientLabel}.formsort.app` +
-        `/client/${clientLabel}/flow/${flowLabel}/variant/${variantLabel}`
+        `/flow/${flowLabel}/variant/${variantLabel}`
     );
   });
 
@@ -183,7 +183,7 @@ describe('FormsortWebEmbed', () => {
     const iframe = iframes[0];
     expect(iframe.src).toBe(
       `https://${clientLabel}.formsort.app` +
-        `/client/${clientLabel}/flow/${flowLabel}` +
+        `/flow/${flowLabel}` +
         `?${queryParamA}=${queryValueA}&${queryParamB}=${queryValueB}`
     );
   });
@@ -238,12 +238,12 @@ describe('FormsortWebEmbed', () => {
 
     const firstFlowIframe = iframes[0];
     expect(firstFlowIframe.src).toBe(
-      `https://${clientLabel}.formsort.app/client/${clientLabel}/flow/${flowLabel}`
+      `https://${clientLabel}.formsort.app/flow/${flowLabel}`
     );
 
     const secondFlowIframe = iframes[1];
     expect(secondFlowIframe.src).toBe(
-      `https://${clientLabel}.formsort.app/client/${clientLabel}/flow/${secondFlowLabel}`
+      `https://${clientLabel}.formsort.app/flow/${secondFlowLabel}`
     );
 
     const firstFlowFinalized = jest.fn();

--- a/packages/web-embed-api/src/index.ts
+++ b/packages/web-embed-api/src/index.ts
@@ -268,8 +268,11 @@ const FormsortWebEmbed = (
     let url;
 
     if (config.origin) {
+      // If a custom origin is set, we need to add the clientLabel and flowLabel to the Url
       url = `${formsortOrigin}/client/${clientLabel}/flow/${flowLabel}`;
     } else {
+      // If there is no custom origin set in the config
+      // we use the default Flow domain which includes the clientLabel
       url = `${formsortOrigin}/flow/${flowLabel}`;
     }
 

--- a/packages/web-embed-api/src/index.ts
+++ b/packages/web-embed-api/src/index.ts
@@ -265,8 +265,14 @@ const FormsortWebEmbed = (
   ) => {
     // We overwrite `formsortOrigin` because `onWindowMessage` will read it
     formsortOrigin = formsortOrigin || `https://${clientLabel}.${DEFAULT_FLOW_DOMAIN}`;
+    let url;
 
-    let url = `${formsortOrigin}/client/${clientLabel}/flow/${flowLabel}`;
+    if (config.origin) {
+      url = `${formsortOrigin}/client/${clientLabel}/flow/${flowLabel}`;
+    } else {
+      url = `${formsortOrigin}/flow/${flowLabel}`;
+    }
+
     if (variantLabel) {
       url += `/variant/${variantLabel}`;
     }


### PR DESCRIPTION
Implements [FLOW-154](https://formsort.atlassian.net/browse/FLOW-154)

Remove the unnecessary Client label from the default Flow Url. Both URLs work, but the subdomain already defines the client label to be used, so it is simpler.