### PR TITLE
Issue 72 - Support React 18

### DIFF
--- a/packages/custom-question-api/examples/react/package.json
+++ b/packages/custom-question-api/examples/react/package.json
@@ -12,14 +12,14 @@
   },
   "devDependencies": {
     "@parcel/transformer-typescript-tsc": "^2.7.0",
-    "@types/react": "^17.0.39",
-    "@types/react-dom": "^17.0.11",
+    "@types/react": "^18.0.15",
+    "@types/react-dom": "^18.0.6",
     "eslint": "^8.12.0",
     "parcel": "^2.7.0"
   },
   "dependencies": {
     "@formsort/custom-question-api": "^0.1.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   }
 }

--- a/packages/react-embed/examples/event-log/package.json
+++ b/packages/react-embed/examples/event-log/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@babel/core": "^7.16.7",
     "@emotion/react": "^11.7.1",
-    "@formsort/react-embed": "^2.1.0",
+    "@formsort/react-embed": "^3.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/react-embed/examples/event-log/package.json
+++ b/packages/react-embed/examples/event-log/package.json
@@ -15,15 +15,15 @@
     "@babel/core": "^7.16.7",
     "@emotion/react": "^11.7.1",
     "@formsort/react-embed": "^2.1.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@parcel/transformer-typescript-tsc": "^2.7.0",
     "@types/babel__core": "^7.1.16",
     "@types/node": "^16.9.4",
-    "@types/react": "^17.0.22",
-    "@types/react-dom": "^17.0.9",
+    "@types/react": "^18.0.15",
+    "@types/react-dom": "^18.0.6",
     "parcel": "^2.7.0",
     "typescript": "^4.6.3"
   }

--- a/packages/react-embed/examples/event-log/src/index.tsx
+++ b/packages/react-embed/examples/event-log/src/index.tsx
@@ -1,8 +1,7 @@
 import { css } from '@emotion/react';
 import EmbedFlow from '@formsort/react-embed';
-import React from 'react';
-import { Fragment, useState } from 'react';
-import ReactDom from 'react-dom';
+import React, { Fragment, useState, useEffect, StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
 
 const FORMSORT_ORIGIN =
   process.env.FORMSORT_ORIGIN || 'https://flow.formsort.com';
@@ -17,6 +16,9 @@ interface LoggedEvent {
 
 const App = () => {
   const [loggedEvents, setLoggedEvents] = useState<LoggedEvent[]>([]);
+  useEffect(() => {
+    document.title = 'Test';
+  }, []);
 
   const addToEventLog = (
     eventName: string,
@@ -29,78 +31,81 @@ const App = () => {
   };
 
   return (
-    <Fragment>
-      <div
-        css={css`
-          display: flex;
-          flex-direction: column;
-          align-items: center;
-          width: 100%;
-        `}
-      >
-        <h1>Formsort React-Embed Example</h1>
-        <EmbedFlow
-          clientLabel={CLIENT}
-          flowLabel={FLOW}
-          variantLabel={VARIANT}
-          embedConfig={{
-            origin: FORMSORT_ORIGIN,
-            style: {
-              width: '80%',
-              height: '400px',
-            },
-          }}
-          onFlowLoaded={(eventProps) => addToEventLog('FlowLoaded', eventProps)}
-          onFlowFinalized={(eventProps) =>
-            addToEventLog('FlowFinalized', eventProps)
-          }
-          onFlowClosed={(eventProps) => addToEventLog('FlowClosed', eventProps)}
-          onStepLoaded={(eventProps) => addToEventLog('StepLoaded', eventProps)}
-          onStepCompleted={(eventProps) =>
-            addToEventLog('StepCompleted', eventProps)
-          }
-          onRedirect={(eventProps) => {
-            addToEventLog('Redirect', eventProps);
-            // return `{ cancel: true }` to stay on current page
-            return {
-              cancel: true,
-            };
-          }}
-        />
+    // Test production strict mode
+    <StrictMode>
+      <Fragment>
         <div
           css={css`
-            margin-bottom: 2rem;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            width: 100%;
           `}
-        />
-        <div>
-          <div>Event Log:</div>
-          <ul>
-            {loggedEvents.map((event, index) => (
-              <div key={event.name + index.toString()}>
-                <li>Event No. {index + 1}:</li>
-                <ul>
-                  <li>
-                    Event name: <i>{event.name}</i>
-                  </li>
-                  <li>
-                    Event properties:
-                    <pre
-                      css={css`
-                        white-space: pre-line;
-                      `}
-                    >
-                      {event.properties}
-                    </pre>
-                  </li>
-                </ul>
-              </div>
-            ))}
-          </ul>
+        >
+          <h1>Formsort React-Embed Example</h1>
+          <EmbedFlow
+            clientLabel={CLIENT}
+            flowLabel={FLOW}
+            variantLabel={VARIANT}
+            embedConfig={{
+              origin: FORMSORT_ORIGIN,
+              style: {
+                width: '80%',
+                height: '400px',
+              },
+            }}
+            onFlowLoaded={(eventProps) => addToEventLog('FlowLoaded', eventProps)}
+            onFlowFinalized={(eventProps) =>
+              addToEventLog('FlowFinalized', eventProps)
+            }
+            onFlowClosed={(eventProps) => addToEventLog('FlowClosed', eventProps)}
+            onStepLoaded={(eventProps) => addToEventLog('StepLoaded', eventProps)}
+            onStepCompleted={(eventProps) =>
+              addToEventLog('StepCompleted', eventProps)
+            }
+            onRedirect={(eventProps) => {
+              addToEventLog('Redirect', eventProps);
+              // return `{ cancel: true }` to stay on current page
+              return {
+                cancel: true,
+              };
+            }}
+          />
+          <div
+            css={css`
+              margin-bottom: 2rem;
+            `}
+          />
+          <div>
+            <div>Event Log:</div>
+            <ul>
+              {loggedEvents.map((event, index) => (
+                <div key={event.name + index.toString()}>
+                  <li>Event No. {index + 1}:</li>
+                  <ul>
+                    <li>
+                      Event name: <i>{event.name}</i>
+                    </li>
+                    <li>
+                      Event properties:
+                      <pre
+                        css={css`
+                          white-space: pre-line;
+                        `}
+                      >
+                        {event.properties}
+                      </pre>
+                    </li>
+                  </ul>
+                </div>
+              ))}
+            </ul>
+          </div>
         </div>
-      </div>
-    </Fragment>
+      </Fragment>
+    </StrictMode>
   );
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-call
-ReactDom.render(<App />, document.getElementById('root'));
+const root = createRoot(document.getElementById('root')!);
+root.render(<App />, );

--- a/packages/react-embed/examples/event-log/src/index.tsx
+++ b/packages/react-embed/examples/event-log/src/index.tsx
@@ -16,6 +16,8 @@ interface LoggedEvent {
 
 const App = () => {
   const [loggedEvents, setLoggedEvents] = useState<LoggedEvent[]>([]);
+
+  // Test useEffect double render
   useEffect(() => {
     document.title = 'Test';
   }, []);

--- a/packages/react-embed/examples/simple/package.json
+++ b/packages/react-embed/examples/simple/package.json
@@ -11,13 +11,13 @@
     "pack": "echo pass"
   },
   "dependencies": {
-    "@formsort/react-embed": "^2.1.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "@formsort/react-embed": "^2.1.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@types/react": "^17.0.22",
-    "@types/react-dom": "^17.0.9",
+    "@types/react": "^18.0.15",
+    "@types/react-dom": "^18.0.6",
     "typescript": "^4.6.3"
   }
 }

--- a/packages/react-embed/package.json
+++ b/packages/react-embed/package.json
@@ -41,7 +41,8 @@
     "@formsort/eslint-config": "^1.3.7",
     "@testing-library/react": "^11.2.2",
     "@types/jest": "^27.0.1",
-    "@types/react": "^16.9.23",
+    "@types/react": "^18.0.15",
+    "@types/react-dom": "^18.0.6",
     "@typescript-eslint/eslint-plugin": "^5.17.0",
     "eslint": "^8.12.0",
     "eslint-plugin-import": "^2.22.1",
@@ -50,8 +51,8 @@
     "eslint-plugin-react": "^7.21.5",
     "jest": "^27.1.0",
     "prettier": "^2.2.1",
-    "react": "^16.13.0",
-    "react-dom": "^16.13.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "ts-jest": "^27.0.5",
     "typescript": "^4.6.3"
   },
@@ -59,7 +60,7 @@
     "@formsort/web-embed-api": "^2.2.3"
   },
   "peerDependencies": {
-    "react": "^16.13.0 || ^17.0.0"
+    "react": "^16.13.0 || ^17.0.0 || ^18.0.0"
   },
   "jest": {
     "cacheDirectory": "./.jest-cache",

--- a/packages/react-embed/package.json
+++ b/packages/react-embed/package.json
@@ -60,7 +60,7 @@
     "@formsort/web-embed-api": "^2.3.0"
   },
   "peerDependencies": {
-    "react": "^16.13.0 || ^17.0.0 || ^18.0.0"
+    "react": ">=16.13.0, <19.0.0"
   },
   "jest": {
     "cacheDirectory": "./.jest-cache",

--- a/packages/react-embed/package.json
+++ b/packages/react-embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formsort/react-embed",
-  "version": "2.1.3",
+  "version": "3.0.0",
   "description": "Embed formsort flows in react components",
   "publishConfig": {
     "access": "public",
@@ -57,7 +57,7 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "@formsort/web-embed-api": "^2.2.3"
+    "@formsort/web-embed-api": "^2.3.0"
   },
   "peerDependencies": {
     "react": "^16.13.0 || ^17.0.0 || ^18.0.0"

--- a/packages/react-embed/src/__tests__/EmbedFlow.test.tsx
+++ b/packages/react-embed/src/__tests__/EmbedFlow.test.tsx
@@ -22,6 +22,7 @@ describe('EmbedFlow component', () => {
     removeEventListenerMock = jest.fn();
     embedMock = {
       loadFlow: loadMock,
+      unloadFlow: jest.fn(),
       setSize: jest.fn(),
       addEventListener: addEventListenerMock,
       removeEventListener: removeEventListenerMock,

--- a/packages/react-embed/src/index.tsx
+++ b/packages/react-embed/src/index.tsx
@@ -57,7 +57,7 @@ const attachEventListenersToEmbed = (
 const onMount = (
   containerRef: React.RefObject<HTMLDivElement>,
   props: EmbedFlowProps
-): void => {
+): IFormsortWebEmbed | undefined => {
   const containerElement = containerRef.current;
   if (!containerElement) {
     return;
@@ -90,6 +90,8 @@ const onMount = (
     variantLabel,
     queryParams.length ? queryParams : undefined
   );
+
+  return embed;
 };
 
 const EmbedFlow: React.FunctionComponent<EmbedFlowProps> = (props) => {
@@ -97,7 +99,11 @@ const EmbedFlow: React.FunctionComponent<EmbedFlowProps> = (props) => {
   const style = props.embedConfig?.style;
 
   useEffect(() => {
-    onMount(containerRef, props);
+    const embed = onMount(containerRef, props);
+
+    return () => {
+      embed?.unloadFlow();
+    };
   }, []);
 
   return <div ref={containerRef} style={style} />;

--- a/packages/web-embed-api/README.md
+++ b/packages/web-embed-api/README.md
@@ -62,6 +62,10 @@ Starts loading a Formsort variant, or a flow.
 
 Note that variantLabel is optional: if it is not provided, a variant will be chosen at random from that flow.
 
+### `unloadFlow() => void`
+
+Remove inserted iFrame and all its event listeners.
+
 ### `setSize(width: number, height: number) => void`
 
 Set the CSS size of the embed.

--- a/packages/web-embed-api/examples/authenticated-flow/package.json
+++ b/packages/web-embed-api/examples/authenticated-flow/package.json
@@ -16,7 +16,7 @@
   "author": "Formsort Engineering <engineering@formsort.com>",
   "license": "ISC",
   "dependencies": {
-    "@formsort/web-embed-api": "2.2.3"
+    "@formsort/web-embed-api": "2.3.0"
   },
   "devDependencies": {
     "css-loader": "^6.7.1",

--- a/packages/web-embed-api/examples/formsort-embed-example-lit/package.json
+++ b/packages/web-embed-api/examples/formsort-embed-example-lit/package.json
@@ -19,7 +19,7 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "@formsort/web-embed-api": "^2.2.3",
+    "@formsort/web-embed-api": "^2.3.0",
     "lit": "^2.2.1"
   },
   "browerslist": [

--- a/packages/web-embed-api/package.json
+++ b/packages/web-embed-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formsort/web-embed-api",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "description": "Embed Formsort flows within other webpages",
   "publishConfig": {
     "access": "public",

--- a/packages/web-embed-api/src/index.ts
+++ b/packages/web-embed-api/src/index.ts
@@ -28,6 +28,7 @@ export interface IFormsortWebEmbed {
     variantLabel?: string,
     queryParams?: Array<[string, string]>
   ) => void;
+  unloadFlow: () => void;
   setSize: (width: string, height: string) => void;
   addEventListener<K extends keyof IEventMap>(
     eventName: K,
@@ -278,8 +279,14 @@ const FormsortWebEmbed = (
     iframeEl.src = url;
   };
 
+  const unloadFlow = () => {
+    removeListeners();
+    rootEl.removeChild(iframeEl);
+  };
+
   return {
     loadFlow,
+    unloadFlow,
     setSize,
     addEventListener<K extends keyof IEventMap>(
       eventName: K,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1886,14 +1886,14 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@^17.0.11", "@types/react-dom@^17.0.9":
-  version "17.0.14"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.14.tgz#c8f917156b652ddf807711f5becbd2ab018dea9f"
-  integrity sha512-H03xwEP1oXmSfl3iobtmQ/2dHF5aBHr8aUMwyGZya6OW45G+xtdzmq6HkncefiBt5JU8DVyaWl/nWZbjZCnzAQ==
+"@types/react-dom@^18.0.6":
+  version "18.0.6"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.6.tgz#36652900024842b74607a17786b6662dd1e103a1"
+  integrity sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^17.0.22", "@types/react@^17.0.39":
+"@types/react@*":
   version "17.0.43"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.43.tgz#4adc142887dd4a2601ce730bc56c3436fdb07a55"
   integrity sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==
@@ -1902,10 +1902,10 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/react@^16.9.23":
-  version "16.14.24"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.24.tgz#f2c5e9fa78f83f769884b83defcf7924b9eb5c82"
-  integrity sha512-e7U2WC8XQP/xfR7bwhOhNFZKPTfW1ph+MiqtudKb8tSV8RyCsovQx2sNVtKoOryjxFKpHPPC/yNiGfdeVM5Gyw==
+"@types/react@^18.0.15":
+  version "18.0.17"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.17.tgz#4583d9c322d67efe4b39a935d223edcc7050ccf4"
+  integrity sha512-38ETy4tL+rn4uQQi7mB81G7V1g0u2ryquNmsVIOKUAEIDK+3CUjZ6rSRpdvS99dNBnkLFL83qfmtLacGOTIhwQ==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -6792,7 +6792,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.6.2, prop-types@^15.8.1:
+prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -6861,24 +6861,13 @@ raw-body@2.5.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-react-dom@^16.13.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
-  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
+react-dom@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
+  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
-
-react-dom@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
-  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    scheduler "^0.20.2"
+    scheduler "^0.23.0"
 
 react-error-overlay@6.0.9:
   version "6.0.9"
@@ -6900,22 +6889,12 @@ react-refresh@^0.9.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.9.0.tgz#71863337adc3e5c2f8a6bfddd12ae3bfe32aafbf"
   integrity sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==
 
-react@^16.13.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
-  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
+react@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
+  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-
-react@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 read-pkg-up@^7.0.1:
   version "7.0.1"
@@ -7185,21 +7164,12 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+scheduler@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
+  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-
-scheduler@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
-  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 schema-utils@^3.1.0, schema-utils@^3.1.1:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -433,6 +433,13 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@formsort/react-embed@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@formsort/react-embed/-/react-embed-2.1.3.tgz#87e2a596531d7534b62b02778a3c90a899e00487"
+  integrity sha512-QPhakHbVGX3aHvoYsReGBxf6eh5jhRGOKJtgsGRyWp0StJ0jyjoD8VFlKI+qVoSqztqPy/YyKyxwA8mpNiv27g==
+  dependencies:
+    "@formsort/web-embed-api" "^2.2.3"
+
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.5.tgz#2cbaf9a89460da24b5ca6531b8bbfc23e1df50c7"


### PR DESCRIPTION
Fixes #72 

In React Strict mode, the embed renders twice. This PR includes an `unloadFlow` on the Web Embed interface and uses it to remove the effects of double rendering.