### PR TITLE
Send `styleSet` to embedded flow when requested

### DIFF
--- a/packages/constants/src/embed-events/index.ts
+++ b/packages/constants/src/embed-events/index.ts
@@ -51,13 +51,8 @@ export interface IIFrameResizeEventData
   };
 }
 
-export enum StyleSetRequestPayload {
-  ID = 'ID'
-}
-
-export interface IIFrameStyleSetRequestEventData
-  extends IWebEmbedEventData<WebEmbedMessage.EMBED_STYLE_SET_REQUEST_MSG> {
-  payload: StyleSetRequestPayload;
+export type IIFrameStyleSetRequestEventData = IWebEmbedEventData & {
+  type: WebEmbedMessage.EMBED_STYLE_SET_REQUEST_MSG;
 }
 
 export interface IIFrameStyleSetResponseMessage {

--- a/packages/constants/src/embed-events/index.ts
+++ b/packages/constants/src/embed-events/index.ts
@@ -51,4 +51,14 @@ export interface IIFrameResizeEventData
   };
 }
 
+export interface IIFrameStyleSetRequestEventData
+  extends IWebEmbedEventData<WebEmbedMessage.EMBED_STYLE_SET_REQUEST_MSG> {}
+
+export interface IIFrameStyleSetResponseMessage
+  extends IWebEmbedEventData<WebEmbedMessage.EMBED_STYLE_SET_RESPONSE_MSG> {
+  payload: {
+    styleSet?: Record<string, unknown>;
+  };
+}
+
 export type IIFramePushMessage = IIFrameTokenResponseMessage;

--- a/packages/constants/src/embed-events/index.ts
+++ b/packages/constants/src/embed-events/index.ts
@@ -51,8 +51,9 @@ export interface IIFrameResizeEventData
   };
 }
 
-export interface IIFrameStyleSetRequestEventData
-  extends IWebEmbedEventData<WebEmbedMessage.EMBED_STYLE_SET_REQUEST_MSG> {}
+export interface IIFrameStyleSetRequestEventData {
+  type: WebEmbedMessage.EMBED_STYLE_SET_REQUEST_MSG
+}
 
 export interface IIFrameStyleSetResponseMessage
   extends IWebEmbedEventData<WebEmbedMessage.EMBED_STYLE_SET_RESPONSE_MSG> {

--- a/packages/constants/src/embed-events/index.ts
+++ b/packages/constants/src/embed-events/index.ts
@@ -51,15 +51,20 @@ export interface IIFrameResizeEventData
   };
 }
 
-export interface IIFrameStyleSetRequestEventData {
-  type: WebEmbedMessage.EMBED_STYLE_SET_REQUEST_MSG
+export enum StyleSetRequestPayload {
+  ID = 'ID'
 }
 
-export interface IIFrameStyleSetResponseMessage
-  extends IWebEmbedEventData<WebEmbedMessage.EMBED_STYLE_SET_RESPONSE_MSG> {
+export interface IIFrameStyleSetRequestEventData
+  extends IWebEmbedEventData<WebEmbedMessage.EMBED_STYLE_SET_REQUEST_MSG> {
+  payload: StyleSetRequestPayload;
+}
+
+export interface IIFrameStyleSetResponseMessage {
+  type: WebEmbedMessage.EMBED_STYLE_SET_RESPONSE_MSG
   payload: {
     styleSet?: Record<string, unknown>;
   };
 }
 
-export type IIFramePushMessage = IIFrameTokenResponseMessage;
+export type IIFramePushMessage = IIFrameTokenResponseMessage | IIFrameStyleSetResponseMessage;

--- a/packages/constants/src/web-embed-message/index.ts
+++ b/packages/constants/src/web-embed-message/index.ts
@@ -2,6 +2,8 @@ enum WebEmbedMessage {
   EMBED_EVENT_MSG = 'ƒ_wee',
   EMBED_REDIRECT_MSG = 'ƒ_wer',
   EMBED_RESIZE_MSG = 'ƒ_wes',
+  EMBED_STYLE_SET_REQUEST_MSG = 'ƒ_wessreq',
+  EMBED_STYLE_SET_RESPONSE_MSG = 'ƒ_wessres',
   EMBED_TOKEN_REQUEST_MSG = 'ƒ_wetreq',
   EMBED_TOKEN_RESPONSE_MSG = 'ƒ_wetres',
   EMBED_UNAUTHORIZED_MSG = 'ƒ_weua',

--- a/packages/web-embed-api/src/index.ts
+++ b/packages/web-embed-api/src/index.ts
@@ -14,6 +14,7 @@ import {
   isIFrameRedirectEventData,
   isIFrameResizeEventData,
   isIFrameAnalyticsEventData,
+  isIFrameStyleSetRequestEventData,
   isIFrameTokenRequestEventData,
   isIFrameUnauthorizedEventData,
 } from './typeGuards';
@@ -122,6 +123,14 @@ const FormsortWebEmbed = (
     unauthorized: [],
   };
 
+  const onStyleSetRequest = () => {
+    sendMessage({
+      type: WebEmbedMessage.EMBED_STYLE_SET_RESPONSE_MSG,
+      // @ts-ignore - Intentionally omitted from IFormsortWebEmbedConfig
+      payload: config.styleSet || undefined,
+    });
+  };
+
   const onTokenRequest = (data: IIFrameTokenRequestEventData) => {
     const { payload } = data;
 
@@ -209,6 +218,8 @@ const FormsortWebEmbed = (
       onResizeMessage(data);
     } else if (isIFrameUnauthorizedEventData(data)) {
       onUnauthorizedMessage();
+    } else if (isIFrameStyleSetRequestEventData(data)) {
+      onStyleSetRequest();
     }
   };
 

--- a/packages/web-embed-api/src/typeGuards.ts
+++ b/packages/web-embed-api/src/typeGuards.ts
@@ -4,6 +4,7 @@ import {
   IIFrameTokenRequestEventData,
   IIFrameRedirectEventData,
   IIFrameResizeEventData,
+  IIFrameStyleSetRequestEventData,
   IWebEmbedEventData,
 } from '@formsort/constants';
 
@@ -68,4 +69,10 @@ export function isIFrameUnauthorizedEventData(
   data: IWebEmbedEventData
 ): data is IIFrameResizeEventData {
   return data.type === WebEmbedMessage.EMBED_UNAUTHORIZED_MSG;
+}
+
+export function isIFrameStyleSetRequestEventData(
+  data: IWebEmbedEventData
+): data is IIFrameStyleSetRequestEventData {
+  return data.type === WebEmbedMessage.EMBED_STYLE_SET_REQUEST_MSG;
 }


### PR DESCRIPTION
## Summary
Implements [STUDIO-1476](https://formsort.atlassian.net/browse/STUDIO-1476) and [STUDIO-1472](https://formsort.atlassian.net/browse/STUDIO-1472):
- Add shared constants
- Provide style set to the embedded flow when requested

This adds the ability to provide a `config.styleSet` to the embed libraries. This will be useful for themed content templates:
- Flow will consider the `styleSet` from its parent window to take precedence over theme-based `styleSet`
- Provide overriding `styleSet`s from the Studio when rendering content template previews

Note: we are not externally supporting `styleSet` feature, thus the reason for omitting from the type `IFormsortWebEmbedConfig`.