### PR TITLE
fix constants package artifact search regexp

### DIFF
--- a/packages/constants/.craft.yml
+++ b/packages/constants/.craft.yml
@@ -5,7 +5,7 @@ preReleaseCommand: node ../../scripts/pre-release.js
 releaseBranchPrefix: release/constants
 
 requireNames:
-  - /^formsort-constants-v.+\\.tgz$/
+  - /^formsort-constants-v.+\.tgz$/
 targets:
   - name: npm
   - name: github


### PR DESCRIPTION
Fixes the `@formsort/constants` release error about missing artifacts.

See examples [here](https://github.com/formsort/oss/actions/runs/3875355992/jobs/6607776596#step:4:218) and [here](https://github.com/formsort/oss/actions/runs/3833292857/jobs/6524599594#step:4:209).