### PR TITLE
Upgrade `constants` and `web-embed-api` dependency versions

### DIFF
--- a/packages/custom-question-api/package.json
+++ b/packages/custom-question-api/package.json
@@ -46,7 +46,7 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "@formsort/constants": "^1.6.0",
+    "@formsort/constants": "^1.7.0",
     "events": "^3.2.0"
   }
 }

--- a/packages/react-embed/package.json
+++ b/packages/react-embed/package.json
@@ -57,7 +57,7 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "@formsort/web-embed-api": "^2.3.0"
+    "@formsort/web-embed-api": "^2.4.0"
   },
   "peerDependencies": {
     "react": ">=16.13.0, <19.0.0"

--- a/packages/web-embed-api/examples/authenticated-flow/package.json
+++ b/packages/web-embed-api/examples/authenticated-flow/package.json
@@ -16,7 +16,7 @@
   "author": "Formsort Engineering <engineering@formsort.com>",
   "license": "ISC",
   "dependencies": {
-    "@formsort/web-embed-api": "2.3.0"
+    "@formsort/web-embed-api": "2.4.0"
   },
   "devDependencies": {
     "css-loader": "^6.7.1",

--- a/packages/web-embed-api/examples/formsort-embed-example-lit/package.json
+++ b/packages/web-embed-api/examples/formsort-embed-example-lit/package.json
@@ -19,7 +19,7 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "@formsort/web-embed-api": "^2.3.0",
+    "@formsort/web-embed-api": "^2.4.0",
     "lit": "^2.2.1"
   },
   "browerslist": [

--- a/packages/web-embed-api/package.json
+++ b/packages/web-embed-api/package.json
@@ -46,7 +46,7 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "@formsort/constants": "^1.6.0"
+    "@formsort/constants": "^1.7.0"
   },
   "jest": {
     "cacheDirectory": "./.jest-cache",

--- a/yarn.lock
+++ b/yarn.lock
@@ -440,13 +440,6 @@
   dependencies:
     "@formsort/web-embed-api" "^2.2.3"
 
-"@formsort/web-embed-api@2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@formsort/web-embed-api/-/web-embed-api-2.3.0.tgz#c8479c304058603f35b838477a9a056e4d9030b5"
-  integrity sha512-Garo8rVZTInH6MzUXH2Up6jFEs38tT2r45nRbbrgCjk1ZIpFlOqnNvw49gF+8ng342xyrbfQS2HwMRMUVzLygw==
-  dependencies:
-    "@formsort/constants" "^1.6.0"
-
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.5.tgz#2cbaf9a89460da24b5ca6531b8bbfc23e1df50c7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -440,6 +440,13 @@
   dependencies:
     "@formsort/web-embed-api" "^2.2.3"
 
+"@formsort/web-embed-api@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@formsort/web-embed-api/-/web-embed-api-2.3.0.tgz#c8479c304058603f35b838477a9a056e4d9030b5"
+  integrity sha512-Garo8rVZTInH6MzUXH2Up6jFEs38tT2r45nRbbrgCjk1ZIpFlOqnNvw49gF+8ng342xyrbfQS2HwMRMUVzLygw==
+  dependencies:
+    "@formsort/constants" "^1.6.0"
+
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.5.tgz#2cbaf9a89460da24b5ca6531b8bbfc23e1df50c7"


### PR DESCRIPTION
## Summary
Upgrade all versions of `@formsort/constants` and `@formsort/web-embed-api` dependencies in all packages, to the latest release.

After this PR is merged, I'll cut a release for the following packages:
- `@formsort/custom-question-api`
- `@formsort/react-embed`
- `@formsort/web-embed-api`

## Testing
Successfully ran [formsort-embed-example-lit](https://github.com/formsort/oss/tree/master/packages/web-embed-api/examples/formsort-embed-example-lit) locally, which tests `@formsort/web-embed-api`.

> ![Screen Shot 2023-01-11 at 4 08 41 PM](https://user-images.githubusercontent.com/32101487/211918397-af0e27cb-3a20-4fe3-bfe5-f83217dca872.png)
