### PR TITLE
Upgrade `constants` package dependency versions

### DIFF
--- a/packages/custom-question-api/package.json
+++ b/packages/custom-question-api/package.json
@@ -46,7 +46,7 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "@formsort/constants": "^1.6.0",
+    "@formsort/constants": "^1.7.0",
     "events": "^3.2.0"
   }
 }

--- a/packages/web-embed-api/package.json
+++ b/packages/web-embed-api/package.json
@@ -46,7 +46,7 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "@formsort/constants": "^1.6.0"
+    "@formsort/constants": "^1.7.0"
   },
   "jest": {
     "cacheDirectory": "./.jest-cache",

--- a/yarn.lock
+++ b/yarn.lock
@@ -440,6 +440,13 @@
   dependencies:
     "@formsort/web-embed-api" "^2.2.3"
 
+"@formsort/web-embed-api@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@formsort/web-embed-api/-/web-embed-api-2.3.0.tgz#c8479c304058603f35b838477a9a056e4d9030b5"
+  integrity sha512-Garo8rVZTInH6MzUXH2Up6jFEs38tT2r45nRbbrgCjk1ZIpFlOqnNvw49gF+8ng342xyrbfQS2HwMRMUVzLygw==
+  dependencies:
+    "@formsort/constants" "^1.6.0"
+
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.5.tgz#2cbaf9a89460da24b5ca6531b8bbfc23e1df50c7"


### PR DESCRIPTION
## Summary
Upgrade `@formsort/constants` dependency versions in:
- web-embed-api
- custom-question-api

Steps to follow up on after this PR is merged:
- Release new version of web-embed-api (as a patch)
- Upgrade web-embed-api dependency versions (ex. in react-embed)
- Release new version of custom-question-api (as a patch)
- Upgrade custom-question-api dependency versions (ex. in examples/)