### PR TITLE
Upgrade dependency version for `react-embed`

### DIFF
--- a/packages/react-embed/examples/event-log/package.json
+++ b/packages/react-embed/examples/event-log/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@babel/core": "^7.16.7",
     "@emotion/react": "^11.7.1",
-    "@formsort/react-embed": "^3.0.0",
+    "@formsort/react-embed": "^3.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/react-embed/examples/simple/package.json
+++ b/packages/react-embed/examples/simple/package.json
@@ -11,7 +11,7 @@
     "pack": "echo pass"
   },
   "dependencies": {
-    "@formsort/react-embed": "^2.1.3",
+    "@formsort/react-embed": "^3.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -433,13 +433,6 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@formsort/react-embed@^2.1.3":
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@formsort/react-embed/-/react-embed-2.1.3.tgz#87e2a596531d7534b62b02778a3c90a899e00487"
-  integrity sha512-QPhakHbVGX3aHvoYsReGBxf6eh5jhRGOKJtgsGRyWp0StJ0jyjoD8VFlKI+qVoSqztqPy/YyKyxwA8mpNiv27g==
-  dependencies:
-    "@formsort/web-embed-api" "^2.2.3"
-
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.5.tgz#2cbaf9a89460da24b5ca6531b8bbfc23e1df50c7"


### PR DESCRIPTION
## Summary
Follow up to https://github.com/formsort/oss/pull/91. Upgrades dependency version for `@formsort/react-embed`.

This wraps up the package version upgrade saga 🥳