### PR TITLE
Add a ResponderStateUpdated analytics event type

### DIFF
--- a/packages/constants/src/analytics-event-type/index.ts
+++ b/packages/constants/src/analytics-event-type/index.ts
@@ -7,6 +7,7 @@ enum AnalyticsEventType {
   EmailCollected = 'EmailCollected',
   FlowFinalized = 'FlowFinalized',
   PhoneCollected = 'PhoneCollected',
+  ResponderStateUpdated = 'ResponderStateUpdated',
 }
 
 export default AnalyticsEventType;


### PR DESCRIPTION
This will be used on the flow side to allow users of the embed to subscribe to changes to the responder state with the same frequency as saveAnswers() is called, so that they can implement answer saving / loading on their own.