### PR TITLE
FLOW-606: make new embed messaging class a package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Build prerequisites first
         run: |
           yarn workspace @formsort/constants run build
+          yarn workspace @formsort/embed-messaging-manager run build
           yarn workspace @formsort/web-embed-api run build
       - name: Build
         run: yarn build

--- a/packages/embed-messaging-manager/.craft.yml
+++ b/packages/embed-messaging-manager/.craft.yml
@@ -1,0 +1,12 @@
+minVersion: '0.32.0'
+changelogPolicy: auto
+preReleaseCommand: node ../../scripts/pre-release.js
+
+releaseBranchPrefix: release/embed-messaging-manager
+
+requireNames:
+  - /^formsort-embed-messaging-manager-v.+\.tgz$/
+targets:
+  - name: npm
+  - name: github
+    tagPrefix: embed-messaging-manager-

--- a/packages/embed-messaging-manager/.prettierrc
+++ b/packages/embed-messaging-manager/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/packages/embed-messaging-manager/LICENSE
+++ b/packages/embed-messaging-manager/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Formsort
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/embed-messaging-manager/README.md
+++ b/packages/embed-messaging-manager/README.md
@@ -1,0 +1,8 @@
+# @formsort/embed-messaging-manager
+
+This package is used internally by Formsort to manage messaging between the embed and the parent page or application.
+
+Not intended to be used directly. You're probably looking for:
+
+- [@formsort/web-embed-api](../web-embed-api) if you want to embed Formsort in a web page.
+- [@formsort/react-embed](../web-embed-api) if you want to embed Formsort embed in a react application.

--- a/packages/embed-messaging-manager/package.json
+++ b/packages/embed-messaging-manager/package.json
@@ -7,7 +7,8 @@
     "format": "eslint --ext .ts,.tsx src --fix",
     "lint": "eslint --ext .ts,.tsx src",
     "test": "jest",
-    "build": "echo noop"
+    "build": "echo noop",
+    "pack": "echo noop"
   },
   "main": "src/index.ts",
   "repository": {

--- a/packages/embed-messaging-manager/package.json
+++ b/packages/embed-messaging-manager/package.json
@@ -25,21 +25,21 @@
   },
   "jest": {
     "cacheDirectory": "./.jest-cache",
-    "transform": {
-      "^.+\\.(t|j)sx?$": "ts-jest"
-    },
-    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    "roots": [
+      "<rootDir>/src"
+    ],
+    "testMatch": [
+      "**/__tests__/**/*.+(ts|tsx|js)",
+      "**/?(*.)+(spec|test).+(ts|tsx|js)"
+    ],
     "testPathIgnorePatterns": [
       "/node_modules/",
-      "/lib/"
+      "/lib/",
+      "/dist/"
     ],
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "jsx",
-      "json",
-      "node"
-    ]
+    "transform": {
+      "^.+\\.(ts|tsx)$": "ts-jest"
+    },
+    "testEnvironment": "jsdom"
   }
 }

--- a/packages/embed-messaging-manager/package.json
+++ b/packages/embed-messaging-manager/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@formsort/embed-messaging-manager",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Utility package used across Formsort projects. Not intended to be used directly",
+  "scripts": {
+    "format": "eslint --ext .ts,.tsx src --fix",
+    "lint": "eslint --ext .ts,.tsx src",
+    "test": "jest",
+    "build": "echo noop"
+  },
+  "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/formsort/oss.git"
+  },
+  "author": "Formsort Engineering <engineering@formsort.com>",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/jest": "^26.0.19",
+    "eslint": "^8.12.0",
+    "jest": "^29.5.0",
+    "ts-jest": "^29.1.0",
+    "typescript": "^4.6.3"
+  },
+  "jest": {
+    "cacheDirectory": "./.jest-cache",
+    "transform": {
+      "^.+\\.(t|j)sx?$": "ts-jest"
+    },
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/lib/"
+    ],
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ]
+  }
+}

--- a/packages/embed-messaging-manager/package.json
+++ b/packages/embed-messaging-manager/package.json
@@ -1,16 +1,22 @@
 {
   "name": "@formsort/embed-messaging-manager",
   "version": "0.1.0",
-  "private": true,
   "description": "Utility package used across Formsort projects. Not intended to be used directly",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
+    "test": "jest",
+    "coverage": "jest --coverage",
+    "build": "tsc --project tsconfig.build.json",
     "format": "eslint --ext .ts,.tsx src --fix",
     "lint": "eslint --ext .ts,.tsx src",
-    "test": "jest",
-    "build": "echo noop",
-    "pack": "echo noop"
+    "pack": "yarn pack",
+    "release": "craft prepare --publish"
   },
-  "main": "src/index.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/formsort/oss.git"

--- a/packages/embed-messaging-manager/src/index.ts
+++ b/packages/embed-messaging-manager/src/index.ts
@@ -1,0 +1,233 @@
+import {
+  AnalyticsEventType,
+  type IIFrameAnalyticsEventData,
+  type IIFrameRedirectEventData,
+  type IIFrameTokenRequestEventData,
+  TokenRequestPayload,
+  type IFlowAnswers,
+  type IIFramePushMessage,
+  WebEmbedMessage,
+} from '@formsort/constants';
+import {
+  isIFrameAnalyticsEventData,
+  isIFrameRedirectEventData,
+  isIFrameResizeEventData,
+  isIFrameStyleSetRequestEventData,
+  isIFrameTokenRequestEventData,
+  isIFrameUnauthorizedEventData,
+  isIWebEmbedEventData
+} from './typeGuards';
+import { addToArrayMap, isEmpty, removeFromArrayMap } from './utils';
+
+interface IAuthenticationConfig {
+  idToken: string;
+}
+
+export interface IFormsortEmbedConfig {
+  autoHeight?: boolean;
+  style?: Partial<Pick<CSSStyleDeclaration, 'width' | 'height'>>;
+  /**
+   * For Formsort internal use only
+   */
+  styleSet?: Record<string, unknown>;
+  origin?: string;
+  authentication?: IAuthenticationConfig;
+}
+
+export const isSupportedEventType = (
+  eventType: AnalyticsEventType | SupportedAnalyticsEvent
+): eventType is SupportedAnalyticsEvent => eventType in SupportedAnalyticsEvent;
+
+export enum SupportedAnalyticsEvent {
+  FlowLoaded = AnalyticsEventType.FlowLoaded,
+  FlowClosed = AnalyticsEventType.FlowClosed,
+  FlowFinalized = AnalyticsEventType.FlowFinalized,
+  StepLoaded = AnalyticsEventType.StepLoaded,
+  StepCompleted = AnalyticsEventType.StepCompleted,
+  ResponderStateUpdated = AnalyticsEventType.ResponderStateUpdated,
+}
+
+interface IBaseEventData {
+  answers: IFlowAnswers | undefined;
+}
+
+interface IRedirectEventData extends IBaseEventData {
+  url: string;
+}
+
+export type IEventListener = (props: IBaseEventData) => void;
+
+export type IAnalyticsEventMap = Record<
+  SupportedAnalyticsEvent,
+  IEventListener
+>;
+
+export interface IEventMap extends IAnalyticsEventMap {
+  redirect: (props: IRedirectEventData) => {
+    cancel?: boolean;
+  } | void;
+  unauthorized: () => void;
+}
+
+export type IEventListenersArrayMap = {
+  [K in keyof IEventMap]: Array<IEventMap[K]>;
+};
+
+interface IManagerParams {
+  config: IFormsortEmbedConfig;
+  onFlowClosed: () => void;
+  onRedirect?: (url: string) => void;
+  onResize: (width?: number, height?: number) => void;
+  sendMessageToEmbed: (message: IIFramePushMessage) => void;
+}
+
+class EmbedMessagingManager {
+  private readonly config: IManagerParams['config'];
+  private readonly onFlowClosed: IManagerParams['onFlowClosed'];
+  private readonly onRedirect?: IManagerParams['onRedirect'];
+  private readonly onResize: IManagerParams['onResize'];
+  private readonly sendMessageToEmbed: IManagerParams['sendMessageToEmbed'];
+
+  private readonly eventListenersArrayMap: IEventListenersArrayMap = {
+    [SupportedAnalyticsEvent.FlowLoaded]: [],
+    [SupportedAnalyticsEvent.FlowClosed]: [],
+    [SupportedAnalyticsEvent.FlowFinalized]: [],
+    [SupportedAnalyticsEvent.StepLoaded]: [],
+    [SupportedAnalyticsEvent.StepCompleted]: [],
+    [SupportedAnalyticsEvent.ResponderStateUpdated]: [],
+    redirect: [],
+    unauthorized: [],
+  };
+
+  constructor({
+    config,
+    onFlowClosed,
+    onRedirect,
+    onResize,
+    sendMessageToEmbed,
+  }: IManagerParams) {
+    this.sendMessageToEmbed = sendMessageToEmbed;
+    this.config = config;
+    this.onRedirect = onRedirect;
+    this.onResize = onResize;
+    this.onFlowClosed = onFlowClosed;
+  }
+
+  private onStyleSetRequest = () => {
+    this.sendMessageToEmbed({
+      type: WebEmbedMessage.EMBED_STYLE_SET_RESPONSE_MSG,
+      payload: { styleSet: this.config.styleSet },
+    });
+  };
+
+  private onTokenRequest = (data: IIFrameTokenRequestEventData) => {
+    const { payload } = data;
+
+    if (payload === TokenRequestPayload.ID) {
+      if (this.config.authentication?.idToken) {
+        this.sendMessageToEmbed({
+          type: WebEmbedMessage.EMBED_TOKEN_RESPONSE_MSG,
+          payload: { token: this.config.authentication.idToken },
+        });
+      } else {
+        throw new Error(
+          `The loaded Flow requires authentication using an ID token, please provide it in config.authentication.idToken.`
+        );
+      }
+    }
+  };
+
+  private onRedirectMessage = (redirectData: IIFrameRedirectEventData) => {
+    const { payload: url, answers } = redirectData;
+
+    if (!isEmpty(this.eventListenersArrayMap.redirect)) {
+      let cancelRedirect = false;
+      // Cancel redirect if any of the redirect listeners return `{ cancel: true }`
+      for (const redirectListener of this.eventListenersArrayMap.redirect) {
+        const { cancel } = redirectListener({ url, answers }) || {};
+        if (!cancelRedirect && cancel) {
+          cancelRedirect = true;
+        }
+      }
+
+      if (cancelRedirect) {
+        return;
+      }
+    }
+
+    this.onRedirect?.(url);
+  };
+
+  private onUnauthorizedMessage = () => {
+    if (!isEmpty(this.eventListenersArrayMap.unauthorized)) {
+      for (const unathorizedListener of this.eventListenersArrayMap.unauthorized) {
+        unathorizedListener();
+      }
+    }
+  };
+
+  private getEventListenerArray = (
+    eventType: AnalyticsEventType
+  ): IEventListener[] | undefined => {
+    if (isSupportedEventType(eventType)) {
+      return this.eventListenersArrayMap[eventType];
+    }
+
+    return undefined;
+  };
+
+  private onEventMessage = (eventData: IIFrameAnalyticsEventData) => {
+    const { eventType, answers } = eventData;
+
+    if (eventType === AnalyticsEventType.FlowClosed) {
+      this.onFlowClosed();
+    }
+
+    const eventListenersArr = this.getEventListenerArray(eventType);
+
+    if (!eventListenersArr) {
+      return;
+    }
+
+    for (const eventListener of eventListenersArr) {
+      eventListener({ answers });
+    }
+  };
+
+  onMessage = (data: unknown) => {
+    if (!isIWebEmbedEventData(data)) {
+      return;
+    }
+
+    if (isIFrameAnalyticsEventData(data)) {
+      this.onEventMessage(data);
+    } else if (isIFrameTokenRequestEventData(data)) {
+      this.onTokenRequest(data);
+    } else if (isIFrameRedirectEventData(data)) {
+      this.onRedirectMessage(data);
+    } else if (isIFrameResizeEventData(data) && this.config.autoHeight) {
+      const { width, height } = data.payload;
+      this.onResize?.(width, height);
+    } else if (isIFrameUnauthorizedEventData(data)) {
+      this.onUnauthorizedMessage();
+    } else if (isIFrameStyleSetRequestEventData(data)) {
+      this.onStyleSetRequest();
+    }
+  }
+
+  addEventListener = <K extends keyof IEventMap>(
+    eventName: K,
+    fn: IEventMap[K]
+  ) => {
+    addToArrayMap(this.eventListenersArrayMap, eventName, fn);
+  };
+
+  removeEventListener = <K extends keyof IEventMap>(
+    eventName: K,
+    eventListener: IEventMap[K]
+  ) => {
+    removeFromArrayMap(this.eventListenersArrayMap, eventName, eventListener);
+  };
+}
+
+export default EmbedMessagingManager;

--- a/packages/embed-messaging-manager/src/typeGuards.test.ts
+++ b/packages/embed-messaging-manager/src/typeGuards.test.ts
@@ -1,0 +1,18 @@
+import { WebEmbedMessage } from '@formsort/constants';
+import { isIWebEmbedEventData } from './typeGuards';
+
+describe('isIWebEmbedEventData', () => {
+  test.each([1, 'hello', null, undefined, {}, { type: 'hello' }])(
+    '%p is not IWebEmbedEventData',
+    (val) => {
+      expect(isIWebEmbedEventData(val)).toEqual(false);
+    }
+  );
+
+  test.each(Object.values(WebEmbedMessage).map((type) => ({ type })))(
+    '%p is IWebEmbedEventData',
+    (val) => {
+      expect(isIWebEmbedEventData(val)).toEqual(true);
+    }
+  );
+});

--- a/packages/embed-messaging-manager/src/typeGuards.ts
+++ b/packages/embed-messaging-manager/src/typeGuards.ts
@@ -1,0 +1,78 @@
+import {
+  WebEmbedMessage,
+  IIFrameAnalyticsEventData,
+  IIFrameTokenRequestEventData,
+  IIFrameRedirectEventData,
+  IIFrameResizeEventData,
+  IIFrameStyleSetRequestEventData,
+  IWebEmbedEventData,
+} from '@formsort/constants';
+
+function isRecord(val: unknown): val is { [key: string]: unknown } {
+  return val !== null && typeof val === 'object';
+}
+
+function isString(val: unknown): val is string {
+  return typeof val === 'string';
+}
+
+/**
+ * Checks if `val` is equal to one of the values of the enum
+ * @param val
+ * @param anEnum
+ */
+const isEnumMember = <EnumType extends { [key: string]: unknown }>(
+  val: unknown,
+  anEnum: EnumType
+): val is EnumType[keyof EnumType] =>
+  Object.values(anEnum).includes(val as EnumType[keyof EnumType]);
+
+export function isIWebEmbedEventData(val: unknown): val is IWebEmbedEventData {
+  return (
+    isRecord(val) &&
+    isString(val.type) &&
+    isEnumMember(val.type, WebEmbedMessage)
+  );
+}
+
+/**
+ * Note: The type guards below are not comprehensive -
+ * i.e. we are not checking that all properties of the expected type exist
+ * on the given value.
+ */
+
+export function isIFrameAnalyticsEventData(
+  data: IWebEmbedEventData
+): data is IIFrameAnalyticsEventData {
+  return data.type === WebEmbedMessage.EMBED_EVENT_MSG;
+}
+
+export function isIFrameTokenRequestEventData(
+  data: IWebEmbedEventData
+): data is IIFrameTokenRequestEventData {
+  return data.type === WebEmbedMessage.EMBED_TOKEN_REQUEST_MSG;
+}
+
+export function isIFrameRedirectEventData(
+  data: IWebEmbedEventData
+): data is IIFrameRedirectEventData {
+  return data.type === WebEmbedMessage.EMBED_REDIRECT_MSG;
+}
+
+export function isIFrameResizeEventData(
+  data: IWebEmbedEventData
+): data is IIFrameResizeEventData {
+  return data.type === WebEmbedMessage.EMBED_RESIZE_MSG;
+}
+
+export function isIFrameUnauthorizedEventData(
+  data: IWebEmbedEventData
+): data is IIFrameResizeEventData {
+  return data.type === WebEmbedMessage.EMBED_UNAUTHORIZED_MSG;
+}
+
+export function isIFrameStyleSetRequestEventData(
+  data: IWebEmbedEventData
+): data is IIFrameStyleSetRequestEventData {
+  return data.type === WebEmbedMessage.EMBED_STYLE_SET_REQUEST_MSG;
+}

--- a/packages/embed-messaging-manager/src/utils.ts
+++ b/packages/embed-messaging-manager/src/utils.ts
@@ -1,0 +1,24 @@
+import { ArrayMap, ElementType } from '@formsort/constants';
+
+export function addToArrayMap<T extends ArrayMap, K extends keyof T>(
+  arrayMap: T,
+  key: K,
+  val: ElementType<T[K]>
+) {
+  arrayMap[key].push(val);
+}
+
+export function removeFromArrayMap<T extends ArrayMap, K extends keyof T>(
+  arrayMap: T,
+  key: K,
+  val: ElementType<T[K]>
+) {
+  const indexOfElem = arrayMap[key].findIndex((elem) => elem === val);
+  if (indexOfElem !== -1) {
+    arrayMap[key].splice(indexOfElem, 1);
+  }
+}
+
+export function isEmpty<T>(val: T[]): val is [] {
+  return val.length === 0;
+}

--- a/packages/embed-messaging-manager/tsconfig.build.json
+++ b/packages/embed-messaging-manager/tsconfig.build.json
@@ -5,5 +5,5 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "exclude": ["lib", "__tests__", "node_modules"]
+  "exclude": ["lib", "**/*.test.ts", "**/*.test.tsx", "node_modules"]
 }

--- a/packages/embed-messaging-manager/tsconfig.build.json
+++ b/packages/embed-messaging-manager/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest"],
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["lib", "__tests__", "node_modules"]
+}

--- a/packages/embed-messaging-manager/tsconfig.json
+++ b/packages/embed-messaging-manager/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@formsort/tsconfig",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "./lib",
+    "strict": true,
+    "types": ["jest"]
+  },
+  "exclude": ["lib"],
+}

--- a/packages/web-embed-api/src/index.ts
+++ b/packages/web-embed-api/src/index.ts
@@ -1,7 +1,7 @@
 import EmbedMessagingManager, {
   type IFormsortEmbedConfig,
   type IEventMap,
-} from '@formsort/embed-messaging-manager';
+} from './EmbedMessagingManager';
 import { getMessageSender } from './iframe-utils';
 
 const DEFAULT_FLOW_ORIGIN = 'https://flow.formsort.com';

--- a/packages/web-embed-api/src/index.ts
+++ b/packages/web-embed-api/src/index.ts
@@ -1,7 +1,7 @@
 import EmbedMessagingManager, {
   type IFormsortEmbedConfig,
   type IEventMap,
-} from './EmbedMessagingManager';
+} from '@formsort/embed-messaging-manager';
 import { getMessageSender } from './iframe-utils';
 
 const DEFAULT_FLOW_ORIGIN = 'https://flow.formsort.com';

--- a/packages/web-embed-api/tsconfig.build.json
+++ b/packages/web-embed-api/tsconfig.build.json
@@ -5,5 +5,5 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "exclude": ["lib", "__tests__", "node_modules"]
+  "exclude": ["lib", "**/*.test.ts", "**/*.test.tsx", "node_modules"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -735,6 +735,13 @@
     "@formsort/constants" "^1.7.0"
     events "^3.2.0"
 
+"@formsort/web-embed-api@2.4.1":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@formsort/web-embed-api/-/web-embed-api-2.4.1.tgz#d1911e4688e45fe88c81fe8269733c3d7b09a361"
+  integrity sha512-n73J+obmu3QGu0IKk/f8JGhlgaqvfut13W/lO91BREJH7ZVh5/sKQlevc/bbaxOeOWXV+keJ9zopT7zfy3PV3Q==
+  dependencies:
+    "@formsort/constants" "^1.7.0"
+
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.5.tgz#2cbaf9a89460da24b5ca6531b8bbfc23e1df50c7"


### PR DESCRIPTION
Copies [EmbedMessagingManager](<https://github.com/formsort/oss/blob/master/packages/web-embed-api/src/EmbedMessagingManager.ts>) to a package.

Follow-up #106

After publishing this package, we're gonna replace  the class with this package and use this package to build a React native embed library.
