### PR TITLE
Prepare embed-messaging-manager for release

### DIFF
--- a/packages/embed-messaging-manager/package.json
+++ b/packages/embed-messaging-manager/package.json
@@ -23,6 +23,9 @@
   },
   "author": "Formsort Engineering <engineering@formsort.com>",
   "license": "MIT",
+  "dependencies": {
+    "@formsort/constants": "^1.10.0"
+  },
   "devDependencies": {
     "@types/jest": "^26.0.19",
     "eslint": "^8.12.0",


### PR DESCRIPTION
in #111, `constants` and `embed-messaging-manager` were updated.
So we need to cut releases for dependent packages step by step.