### PR TITLE
fix: removing missing childNode error

### DIFF
--- a/packages/web-embed-api/src/index.ts
+++ b/packages/web-embed-api/src/index.ts
@@ -59,7 +59,9 @@ const FormsortWebEmbed = (
 
   const unloadFlow = () => {
     removeListeners();
-    rootEl.removeChild(iframeEl);
+    if (iframeEl.contentDocument) {
+      rootEl.removeChild(iframeEl);
+    }
   };
 
   const messagingManager = new EmbedMessagingManager({


### PR DESCRIPTION
Only remove the child if iframe still contains contentDocument. If user clicks on the close hyperlink in the embed, contentDocument will be removed.

should fix: #128 

or some fix along the line of this