### PR TITLE
fix(ci): restrict workflow artifact path to package roots

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           name: ${{ github.sha }}
           if-no-files-found: error
-          path: |
-            ${{ github.workspace }}/packages/**/*.tgz
-            !node_modules/**/*
+          # Match only the .tgz produced in each package's own root.
+          # The broader `packages/**/*.tgz` pattern follows pnpm's node_modules
+          # symlinks into sibling workspace packages, bundling stray copies.
+          path: ${{ github.workspace }}/packages/*/*.tgz


### PR DESCRIPTION
Narrow the GitHub Actions upload path in .github/workflows/build.yml to only match .tgz files in each package root (packages/*/*.tgz). This prevents the previous packages/**/*.tgz pattern from following pnpm node_modules symlinks into sibling workspace packages and bundling stray duplicate copies; added inline comments explaining the change.